### PR TITLE
Change versions: JVM to 17, Kotlin to 1.8.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.8.0'
+    id 'org.jetbrains.kotlin.jvm' version '1.8.20'
     id 'application'
 }
 
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     implementation "io.insert-koin:koin-core:$koin_version"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.0"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.20"
 
 
     // Data Access
@@ -40,7 +40,7 @@ test {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }
 
 application {


### PR DESCRIPTION
On Apple M1 this project fails as it is unable to download Java 8 SDK for aarch64, as Gradle toolchain autoprovisioning api does not have JDKs 1.8 for Mac M1: https://adoptium.net/temurin/releases/?version=8 

Any build will be returning the error of:

```
> Could not read 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/adoptopenjdk' as it does not exist.
```

Workaround is to change the toolchain to minimum 11, here I changed it to 17. Also bumped the kotlin version to 1.8.20. Otherwise, the combination of JVM 17 with Kotlin 1.8.0 would return a lot of unresolved reference.

Have yet to test in non-M1 Mac, but rebuilt in M1 Mac finished successfully:
```
rm -rf ~/.gradle 
./gradlew build  

BUILD SUCCESSFUL in 31s
7 actionable tasks: 7 executed
```
