### PR TITLE
Change Game ID from UUID to Serial

### DIFF
--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -7,7 +7,6 @@ import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
 interface GameDao {
      @SqlUpdate("""
           INSERT INTO GAME(
-               gameId,
                gameName,
                windowStart,
                windowClose,
@@ -17,7 +16,6 @@ interface GameDao {
                gameActive
           )
           VALUES (
-               :game.gameId,
                :game.gameName,
                :game.windowStart,
                :game.windowClose,

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Game.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Game.kt
@@ -1,10 +1,9 @@
 package uk.co.mutuallyassureddistraction.paketliga.dao.entity
 
 import java.time.ZonedDateTime
-import java.util.UUID
 
 data class Game(
-    val gameId: UUID,
+    val gameId: Int,
     val gameName: String,
     val windowStart: ZonedDateTime,
     val windowClose: ZonedDateTime,

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
@@ -44,7 +44,7 @@ fun setUpDatabaseTables(jdbi: Jdbi) {
         """.trimIndent())
         batch.add("""
             CREATE TABLE GAME (
-                gameId uuid not null,
+                gameId SERIAL PRIMARY KEY,
                 gameName VARCHAR(50) not null,
                 windowStart VARCHAR(50) not null,
                 windowClose VARCHAR(50) not null,

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
@@ -46,11 +46,10 @@ class GameDaoTest {
     }
 
     private fun createGame(): Game {
-        val gameId = UUID.randomUUID()
         val gameName = "A random game name for test";
 
         val expected = Game(
-            gameId = gameId,
+            gameId = 1,
             gameName = gameName,
             windowStart = ZonedDateTime.parse("2023-04-07T09:00:00.000Z[Europe/London]"),
             windowClose = ZonedDateTime.parse("2023-04-07T17:00:00.000Z[Europe/London]"),

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameResultResolverTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameResultResolverTest.kt
@@ -85,7 +85,7 @@ class GameResultResolverTest {
 
     private fun buildGame(): Game {
         return Game(
-            gameId = UUID.randomUUID(),
+            gameId = 1,
             gameName = "Testing testing",
             windowStart = ZonedDateTime.now(),
             windowClose = ZonedDateTime.now(),


### PR DESCRIPTION
As title, changing data type in DB from UUID to Serial (or auto-increment I suppose)

Some train of thoughts on this change:
- Do we need UUID? Probably we do if we don't want users to just guess game id and change it without creator or admin permission. But we could probably could gatekeep it with service logic? so probably this is not _that_ (CMIIW) necessary.
- What if one user has multiple games at the same time? I imagine the query to the bot (again CMIIW) would return list of the active games, and ask user which one do they want to change, and then, probably update it by including the game id listed from the response (we can use Ephemeral message / message that is visible only to the user if privacy is a concern). In this case, UUID would probably be a bit long and difficult to write / copy.

Need some comments here if the thoughts made sense.

```
./gradlew build

BUILD SUCCESSFUL in 16s
7 actionable tasks: 5 executed, 2 up-to-date
```