### PR TITLE
Added Constraint to Guess columns and fix test errors

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 BOT_TOKEN=abcde
 SERVER_ID=12345
+
+POSTGRES_JDBC_URL=jdbc:postgresql://db.jpjtuikdwajutyaavomt.supabase.co:5432/postgres
+POSTGRES_PASSWORD=12345

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ version = '1.0-SNAPSHOT'
 // APP
 def koin_version = '3.3.3'
 def jdbi_version = '3.37.1'
+def kotlin_reflect_version = '1.8.20'
+def kord_version = '1.5.6'
+def hawking_version = '0.1.7'
+def postgres_kt_version = '0.9.3'
 
 // TEST
 def test_container_version = '1.17.6'
@@ -21,9 +25,10 @@ repositories {
 
 dependencies {
     implementation "io.insert-koin:koin-core:$koin_version"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.20"
-    implementation "com.kotlindiscord.kord.extensions:kord-extensions:1.5.6"
-    implementation "com.zoho:hawking:0.1.7"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_reflect_version"
+    implementation "com.kotlindiscord.kord.extensions:kord-extensions:$kord_version"
+    implementation "com.zoho:hawking:$hawking_version"
+    implementation "io.github.jan-tennert.supabase:postgrest-kt:$postgres_kt_version"
 
     // Data Access
     implementation "org.jdbi:jdbi3-core:$jdbi_version"

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ def jdbi_version = '3.37.1'
 
 // TEST
 def test_container_version = '1.17.6'
+def mockk_version = '1.13.4'
 
 
 repositories {
@@ -34,6 +35,7 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation "org.testcontainers:testcontainers:$test_container_version"
     testImplementation "org.testcontainers:postgresql:$test_container_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
 }
 
 test {

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -11,7 +11,9 @@ import org.jdbi.v3.sqlobject.kotlin.KotlinSqlObjectPlugin
 import org.jdbi.v3.sqlobject.kotlin.onDemand
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import uk.co.mutuallyassureddistraction.paketliga.extensions.CreateGameExtension
+import uk.co.mutuallyassureddistraction.paketliga.extensions.FindGamesExtension
 import uk.co.mutuallyassureddistraction.paketliga.extensions.UpdateGameExtension
+import uk.co.mutuallyassureddistraction.paketliga.matching.GameFinderService
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 import java.sql.Connection
 import java.sql.DriverManager
@@ -33,9 +35,11 @@ suspend fun main() {
         // initialise GameDao and GameExtension
         val gameDao = jdbi.onDemand<GameDao>()
         val gameUpsertService = GameUpsertService(gameDao)
+        val gameFinderService = GameFinderService(gameDao)
 
         val createGameExtension = CreateGameExtension(gameUpsertService, SERVER_ID)
         val updateGameExtension = UpdateGameExtension(gameUpsertService, SERVER_ID)
+        val findGamesExtension = FindGamesExtension(gameFinderService, SERVER_ID)
 
         val bot = ExtensibleBot(BOT_TOKEN) {
             chatCommands {
@@ -46,6 +50,7 @@ suspend fun main() {
             extensions {
                 add { createGameExtension }
                 add { updateGameExtension }
+                add { findGamesExtension }
             }
         }
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -2,27 +2,55 @@ package uk.co.mutuallyassureddistraction.paketliga
 
 import com.kotlindiscord.kord.extensions.ExtensibleBot
 import com.kotlindiscord.kord.extensions.utils.env
-import dev.kord.common.entity.Snowflake
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.kotlin.KotlinPlugin
+import org.jdbi.v3.postgres.PostgresPlugin
+import org.jdbi.v3.sqlobject.SqlObjectPlugin
+import org.jdbi.v3.sqlobject.kotlin.KotlinSqlObjectPlugin
+import org.jdbi.v3.sqlobject.kotlin.onDemand
+import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import uk.co.mutuallyassureddistraction.paketliga.extensions.GameExtension
-import uk.co.mutuallyassureddistraction.paketliga.extensions.SlapExtension
+import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
+import java.sql.Connection
+import java.sql.DriverManager
 
-val SERVER_ID = Snowflake(
-    env("SERVER_ID").toLong()  // Get the test server ID from the env vars or a .env file
-)
+val PG_JDBC_URL = env("POSTGRES_JDBC_URL")
+val PG_PASSWORD = env("POSTGRES_PASSWORD")
+
 private val BOT_TOKEN = env("BOT_TOKEN") // Get the bot' token from the env vars or a .env file
 
 suspend fun main() {
-    val bot = ExtensibleBot(BOT_TOKEN) {
-        chatCommands {
-            enabled = true
-            prefix { _ -> "?" }
+
+    val connection = DriverManager.getConnection(PG_JDBC_URL, "postgres", PG_PASSWORD)
+    if(connection.isValid(0)) {
+        val jdbi = getJdbi(connection)
+
+        // initialise GameDao and GameExtension
+        val gameDao = jdbi.onDemand<GameDao>()
+        val gameUpsertService = GameUpsertService(gameDao)
+        val gameExtension = GameExtension(gameUpsertService)
+
+        val bot = ExtensibleBot(BOT_TOKEN) {
+            chatCommands {
+                enabled = true
+                prefix { _ -> "?" }
+            }
+
+            extensions {
+                add { gameExtension }
+            }
         }
 
-        extensions {
-//            add(::SlapExtension)
-            add(::GameExtension)
-        }
+        bot.start()
     }
 
-    bot.start()
+    // TODO logging when DB is timeout
+}
+
+private fun getJdbi(connection: Connection): Jdbi {
+    return Jdbi.create(connection)
+        .installPlugin(PostgresPlugin())
+        .installPlugin(SqlObjectPlugin())
+        .installPlugin(KotlinPlugin())
+        .installPlugin(KotlinSqlObjectPlugin())
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -7,7 +7,6 @@ import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
 interface GameDao {
      @SqlUpdate("""
           INSERT INTO GAME(
-               gameId,
                gameName,
                windowStart,
                windowClose,
@@ -17,7 +16,6 @@ interface GameDao {
                gameActive
           )
           VALUES (
-               :game.gameId,
                :game.gameName,
                :game.windowStart,
                :game.windowClose,

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -29,16 +29,18 @@ interface GameDao {
      """)
      fun createGame(game: Game)
 
-     @SqlUpdate("""
+     @SqlQuery("""
           UPDATE GAME
           SET 
                windowStart = COALESCE(:windowStart, windowStart),
                windowClose = COALESCE(:windowClose, windowClose),
                guessesClose = COALESCE(:guessesClose, windowClose)
           WHERE gameId = :id
+          RETURNING *
      """)
      fun updateGameTimes(@Bind("id")gameId: Int, @Bind("windowStart")windowStart: ZonedDateTime?,
-                         @Bind("windowClose")windowClose: ZonedDateTime?, @Bind("guessesClose")guessesClose: ZonedDateTime)
+                         @Bind("windowClose")windowClose: ZonedDateTime?,
+                         @Bind("guessesClose")guessesClose: ZonedDateTime?): Game
 
      @SqlQuery("""
           UPDATE Game
@@ -62,7 +64,7 @@ interface GameDao {
           WHERE gameId = :id
           AND gameActive = 'TRUE'
      """)
-     fun findActiveGameById(@Bind("id")gameId: Int): Game
+     fun findActiveGameById(@Bind("id")gameId: Int): Game?
 
      @SqlQuery("""
           SELECT * FROM GAME

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -1,8 +1,10 @@
 package uk.co.mutuallyassureddistraction.paketliga.dao
 
+import org.jdbi.v3.sqlobject.customizer.Bind
 import org.jdbi.v3.sqlobject.statement.SqlQuery
 import org.jdbi.v3.sqlobject.statement.SqlUpdate
 import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
+import java.time.ZonedDateTime
 
 interface GameDao {
      @SqlUpdate("""
@@ -27,6 +29,27 @@ interface GameDao {
      """)
      fun createGame(game: Game)
 
+     @SqlUpdate("""
+          UPDATE GAME
+          SET 
+               windowStart = COALESCE(:windowStart, windowStart),
+               windowClose = COALESCE(:windowClose, windowClose),
+               guessesClose = COALESCE(:guessesClose, windowClose)
+          WHERE gameId = :id
+     """)
+     fun updateGameTimes(@Bind("id")gameId: Int, @Bind("windowStart")windowStart: ZonedDateTime?,
+                         @Bind("windowClose")windowClose: ZonedDateTime?, @Bind("guessesClose")guessesClose: ZonedDateTime)
+
+     @SqlQuery("""
+          UPDATE Game
+          SET
+               deliveryTime = :deliveryTime,
+               gameActive = 'FALSE'
+          WHERE gameId = :id
+          RETURNING *
+     """)
+     fun finishGame(@Bind("id")gameId: Int, @Bind("deliveryTime")deliveryTime: ZonedDateTime): Game
+
      @SqlQuery("""
           SELECT * FROM GAME
           WHERE gameName LIKE concat('%',:gameName,'%')
@@ -34,4 +57,10 @@ interface GameDao {
      """)
      fun findActiveGameByName(gameName: String): Game
 
+     @SqlQuery("""
+          SELECT * FROM GAME
+          WHERE gameId = :id
+          AND gameActive = 'TRUE'
+     """)
+     fun findActiveGameById(@Bind("id")gameId: Int): Game
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -63,4 +63,11 @@ interface GameDao {
           AND gameActive = 'TRUE'
      """)
      fun findActiveGameById(@Bind("id")gameId: Int): Game
+
+     @SqlQuery("""
+          SELECT * FROM GAME
+          WHERE userId = :id
+          AND gameActive = 'TRUE'
+     """)
+     fun findActiveGamesByUserId(@Bind("id")useId: String): List<Game>
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -54,13 +54,6 @@ interface GameDao {
 
      @SqlQuery("""
           SELECT * FROM GAME
-          WHERE gameName LIKE concat('%',:gameName,'%')
-          AND gameActive = 'TRUE'
-     """)
-     fun findActiveGameByName(gameName: String): Game
-
-     @SqlQuery("""
-          SELECT * FROM GAME
           WHERE gameId = :id
           AND gameActive = 'TRUE'
      """)
@@ -68,8 +61,9 @@ interface GameDao {
 
      @SqlQuery("""
           SELECT * FROM GAME
-          WHERE userId = :id
+          WHERE (:gameName IS NULL OR gameName LIKE concat('%',:gameName,'%'))
+          AND (:userId is NULL OR userId = :userId)
           AND gameActive = 'TRUE'
      """)
-     fun findActiveGamesByUserId(@Bind("id")useId: String): List<Game>
+     fun findActiveGames(gameName: String?, userId: String?): List<Game>
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
@@ -32,5 +32,5 @@ interface GuessDao {
                 FROM GUESS
                 WHERE guessId = :id
     """)
-    fun findGuessByGuessId(@Bind("id") guessId: UUID): Guess
+    fun findGuessByGuessId(@Bind("id") guessId: Int): Guess
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Game.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Game.kt
@@ -3,7 +3,7 @@ package uk.co.mutuallyassureddistraction.paketliga.dao.entity
 import java.time.ZonedDateTime
 
 data class Game(
-    val gameId: Int,
+    val gameId: Int?,
     val gameName: String,
     val windowStart: ZonedDateTime,
     val windowClose: ZonedDateTime,

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Game.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Game.kt
@@ -1,10 +1,9 @@
 package uk.co.mutuallyassureddistraction.paketliga.dao.entity
 
 import java.time.ZonedDateTime
-import java.util.UUID
 
 data class Game(
-    val gameId: UUID,
+    val gameId: Int,
     val gameName: String,
     val windowStart: ZonedDateTime,
     val windowClose: ZonedDateTime,

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Guess.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Guess.kt
@@ -1,11 +1,10 @@
 package uk.co.mutuallyassureddistraction.paketliga.dao.entity
 
 import java.time.ZonedDateTime
-import java.util.UUID
 
 data class Guess(
-    val guessId: UUID,
-    val gameId: UUID,
+    val guessId: Int?,
+    val gameId: Int,
     val userId: String,
     val guessTime: ZonedDateTime
 )

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/CreateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/CreateGameExtension.kt
@@ -6,17 +6,11 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
-import com.kotlindiscord.kord.extensions.utils.env
 import dev.kord.common.entity.Snowflake
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 
-
-val SERVER_ID = Snowflake(
-    env("SERVER_ID").toLong()  // Get the test server ID from the env vars or a .env file
-)
-
-class GameExtension(private val gameUpsertService: GameUpsertService) : Extension() {
-    override val name = "gameExtension"
+class CreateGameExtension(private val gameUpsertService: GameUpsertService, private val serverId: Snowflake) : Extension() {
+    override val name = "createGameExtension"
 
     override suspend fun setup() {
         publicSlashCommand(::PaketGameArgs) {  // Public slash commands have public responses
@@ -24,7 +18,7 @@ class GameExtension(private val gameUpsertService: GameUpsertService) : Extensio
             description = "Ask the bot to create a game of PKL"
 
             // Use guild commands for testing, global ones take up to an hour to update
-            guild(SERVER_ID)
+            guild(serverId)
 
             action {
                 val createGameResponse = gameUpsertService.createGame(

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
@@ -7,6 +7,7 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalUser
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.types.respondEphemeral
 import com.kotlindiscord.kord.extensions.types.respondingPaginator
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.MemberBehavior
@@ -29,37 +30,44 @@ class FindGamesExtension(private val gameFinderService: GameFinderService, priva
                 val gameName = arguments.gamename
                 val userId = arguments.gamecreator?.asUser()?.id?.value?.toString()
 
-                val responseList: List<FindGamesResponse> = gameFinderService.findGames(userId, gameName, gameId)
-
-                val kord = this@FindGamesExtension.kord
-
-                if(responseList.isEmpty()) {
-                    respond {
-                        content = "No games found."
+                if(gameId == null && gameName == null && userId == null) {
+                    respondEphemeral {
+                        content = "No params specified, nothing to be searched."
                     }
                 } else {
-                    val paginator = respondingPaginator {
-                        responseList.chunked(5).map { response ->
-                            val pageFields = ArrayList<EmbedBuilder.Field>()
-                            response.forEach {
-                                val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+                    val responseList: List<FindGamesResponse> = gameFinderService.findGames(userId, gameName, gameId)
 
-                                val field = EmbedBuilder.Field()
-                                field.name = "ID #" + it.gameId.toString() + ": Game by " + memberBehavior.asMember().displayName +
-                                        " - " + it.gameName
-                                field.value = "Arriving between " + it.windowStart + " and " + it.windowClose +
-                                        ".\n Guesses accepted until " + it.guessesClose
-                                pageFields.add(field)
-                            }
+                    val kord = this@FindGamesExtension.kord
 
-                            page {
-                                title = "List of PKL games: "
-                                fields = pageFields
+                    if (responseList.isEmpty()) {
+                        respond {
+                            content = "No games found."
+                        }
+                    } else {
+                        val paginator = respondingPaginator {
+                            responseList.chunked(5).map { response ->
+                                val pageFields = ArrayList<EmbedBuilder.Field>()
+                                response.forEach {
+                                    val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+
+                                    val field = EmbedBuilder.Field()
+                                    field.name =
+                                        "ID #" + it.gameId.toString() + ": Game by " + memberBehavior.asMember().displayName +
+                                                " - " + it.gameName
+                                    field.value = "Arriving between " + it.windowStart + " and " + it.windowClose +
+                                            ".\n Guesses accepted until " + it.guessesClose
+                                    pageFields.add(field)
+                                }
+
+                                page {
+                                    title = "List of PKL games: "
+                                    fields = pageFields
+                                }
                             }
                         }
-                    }
 
-                    paginator.send()
+                        paginator.send()
+                    }
                 }
             }
         }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
@@ -1,0 +1,84 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalInt
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalUser
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.types.respondingPaginator
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.MemberBehavior
+import dev.kord.rest.builder.message.EmbedBuilder
+import uk.co.mutuallyassureddistraction.paketliga.matching.FindGamesResponse
+import uk.co.mutuallyassureddistraction.paketliga.matching.GameFinderService
+
+class FindGamesExtension(private val gameFinderService: GameFinderService, private val serverId: Snowflake) : Extension() {
+    override val name = "findGamesExtension"
+
+    override suspend fun setup() {
+        publicSlashCommand(::FindGamesArgs) {
+            name = "findgames"
+            description = "Ask the bot to find PKL games"
+
+            guild(serverId)
+
+            action {
+                val gameId = arguments.gameid
+                val gameName = arguments.gamename
+                val userId = arguments.gamecreator?.asUser()?.id?.value?.toString()
+
+                val responseList: List<FindGamesResponse> = gameFinderService.findGames(userId, gameName, gameId)
+
+                val kord = this@FindGamesExtension.kord
+
+                if(responseList.isEmpty()) {
+                    respond {
+                        content = "No games found."
+                    }
+                } else {
+                    val paginator = respondingPaginator {
+                        responseList.chunked(5).map { response ->
+                            val pageFields = ArrayList<EmbedBuilder.Field>()
+                            response.forEach {
+                                val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+
+                                val field = EmbedBuilder.Field()
+                                field.name = "ID #" + it.gameId.toString() + ": Game by " + memberBehavior.asMember().displayName +
+                                        " - " + it.gameName
+                                field.value = "Arriving between " + it.windowStart + " and " + it.windowClose +
+                                        ".\n Guesses accepted until " + it.guessesClose
+                                pageFields.add(field)
+                            }
+
+                            page {
+                                title = "List of PKL games: "
+                                fields = pageFields
+                            }
+                        }
+                    }
+
+                    paginator.send()
+                }
+            }
+        }
+    }
+
+    inner class FindGamesArgs : Arguments() {
+        val gamecreator by optionalUser {
+            name = "gamecreator"
+            description = "Creator of the games"
+        }
+
+        val gameid by optionalInt {
+            name = "gameid"
+            description = "ID of the PKL game"
+        }
+
+        val gamename by optionalString {
+            name = "gamename"
+            description = "Name of the game"
+        }
+    }
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
@@ -64,6 +64,9 @@ class FindGamesExtension(private val gameFinderService: GameFinderService, priva
                                     fields = pageFields
                                 }
                             }
+
+                            // This will make the pagination function (next prev etc) to disappear after timeout time
+                            timeoutSeconds = 15L
                         }
 
                         paginator.send()

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/GameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/GameExtension.kt
@@ -1,28 +1,21 @@
 package uk.co.mutuallyassureddistraction.paketliga.extensions
 
 import com.kotlindiscord.kord.extensions.commands.Arguments
-import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingString
 import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
 import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.utils.env
-import com.zoho.hawking.HawkingTimeParser
-import com.zoho.hawking.datetimeparser.configuration.HawkingConfiguration
-import com.zoho.hawking.language.english.model.DatesFound
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.optional.optional
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
-import java.time.ZoneId
-import java.util.*
 
 
 val SERVER_ID = Snowflake(
     env("SERVER_ID").toLong()  // Get the test server ID from the env vars or a .env file
 )
 
-class GameExtension : Extension() {
+class GameExtension(private val gameUpsertService: GameUpsertService) : Extension() {
     override val name = "gameExtension"
 
     override suspend fun setup() {
@@ -34,8 +27,6 @@ class GameExtension : Extension() {
             guild(SERVER_ID)
 
             action {
-                val kord = this@GameExtension.kord
-                val gameUpsertService = GameUpsertService()
                 val createGameResponse = gameUpsertService.createGame(
                     arguments.gamename, arguments.startwindow, arguments.closewindow, arguments.guessesclose,
                     user.asUser().id.value.toString(), member?.asMember(), user.asUser().username

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
@@ -1,0 +1,51 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.int
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respond
+import dev.kord.common.entity.Snowflake
+import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
+
+class UpdateGameExtension(private val gameUpsertService: GameUpsertService, private val serverId: Snowflake) : Extension() {
+    override val name = "updateGameExtension"
+    override suspend fun setup() {
+        publicSlashCommand(::UpdateGameArgs) {
+            name = "updategame"
+            description = "Ask the bot to update a game of PKL"
+
+            guild(serverId)
+
+            action {
+                respond {
+                    content = "game updated"
+                }
+            }
+        }
+    }
+
+    inner class UpdateGameArgs : Arguments() {
+        val gameid by int {
+            name = "gameid"
+            description = "Game id inputted by user"
+        }
+
+        val startwindow by optionalString {
+            name = "startwindow"
+            description = "Start window time inputted by user"
+        }
+
+        val closewindow by optionalString {
+            name = "closewindow"
+            description = "Close window time inputted by user"
+        }
+
+        val guessesclose by optionalString {
+            name = "guessesclose"
+            description = "Close window time inputted by user"
+        }
+    }
+
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
@@ -7,7 +7,6 @@ import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.types.respondEphemeral
-import com.kotlindiscord.kord.extensions.types.respondingPaginator
 import dev.kord.common.entity.Snowflake
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 
@@ -37,10 +36,6 @@ class UpdateGameExtension(private val gameUpsertService: GameUpsertService, priv
 
                     respond {
                         content = updateGameResponse[0]
-                    }
-
-                    respondingPaginator {
-
                     }
                 }
             }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
@@ -7,6 +7,7 @@ import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.types.respondEphemeral
+import com.kotlindiscord.kord.extensions.types.respondingPaginator
 import dev.kord.common.entity.Snowflake
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 
@@ -36,6 +37,10 @@ class UpdateGameExtension(private val gameUpsertService: GameUpsertService, priv
 
                     respond {
                         content = updateGameResponse[0]
+                    }
+
+                    respondingPaginator {
+
                     }
                 }
             }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
@@ -6,6 +6,7 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.types.respondEphemeral
 import dev.kord.common.entity.Snowflake
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 
@@ -19,8 +20,23 @@ class UpdateGameExtension(private val gameUpsertService: GameUpsertService, priv
             guild(serverId)
 
             action {
-                respond {
-                    content = "game updated"
+                val gameId = arguments.gameid
+                val startWindow = arguments.startwindow
+                val closeWindow = arguments.closewindow
+                val guessesClose = arguments.guessesclose
+
+                if(startWindow == null && closeWindow == null && guessesClose == null) {
+                    respondEphemeral {
+                        content = "No time specified, the game will not be updated"
+                    }
+                } else {
+                    val updateGameResponse = gameUpsertService.updateGame(
+                        gameId, startWindow, closeWindow, guessesClose
+                    )
+
+                    respond {
+                        content = updateGameResponse[0]
+                    }
                 }
             }
         }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderService.kt
@@ -1,0 +1,43 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
+import java.time.ZonedDateTime
+
+class GameFinderService(private val gameDao: GameDao) {
+    fun findGames(userId: String?, gameName: String?, gameId: Int?): List<FindGamesResponse> {
+        val gamesResponseList = ArrayList<FindGamesResponse>()
+        if(gameId != null) {
+            val searchedGame: Game? = gameDao.findActiveGameById(gameId)
+            if(searchedGame != null) {
+                gamesResponseList.add(buildResponse(searchedGame))
+            }
+        } else {
+            val searchedGames: List<Game> = gameDao.findActiveGames(gameName, userId)
+            for(searchedGame in searchedGames) {
+                gamesResponseList.add(buildResponse(searchedGame))
+            }
+        }
+
+        return gamesResponseList
+    }
+
+    private fun buildResponse(game: Game): FindGamesResponse {
+        return FindGamesResponse(
+            game.gameId!!,
+            game.userId,
+            game.windowStart,
+            game.windowClose,
+            game.guessesClose
+        )
+    }
+}
+
+class FindGamesResponse(
+    val gameId: Int,
+    val userId: String,
+    val windowStart: ZonedDateTime,
+    val windowClose: ZonedDateTime,
+    val guessesClose: ZonedDateTime
+)
+

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderService.kt
@@ -1,10 +1,17 @@
 package uk.co.mutuallyassureddistraction.paketliga.matching
 
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
-import java.time.ZonedDateTime
+import java.util.*
 
 class GameFinderService(private val gameDao: GameDao) {
+
+    private val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+
     fun findGames(userId: String?, gameName: String?, gameId: Int?): List<FindGamesResponse> {
         val gamesResponseList = ArrayList<FindGamesResponse>()
         if(gameId != null) {
@@ -23,21 +30,30 @@ class GameFinderService(private val gameDao: GameDao) {
     }
 
     private fun buildResponse(game: Game): FindGamesResponse {
+        val startDateString = DateTime(game.windowStart.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(game.windowStart.zone))).toString(dtf)
+        val closeDateString = DateTime(game.windowClose.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(game.windowClose.zone))).toString(dtf)
+        val guessesCloseDateString = DateTime(game.guessesClose.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(game.guessesClose.zone))).toString(dtf)
+
         return FindGamesResponse(
             game.gameId!!,
+            game.gameName,
             game.userId,
-            game.windowStart,
-            game.windowClose,
-            game.guessesClose
+            startDateString,
+            closeDateString,
+            guessesCloseDateString
         )
     }
 }
 
 class FindGamesResponse(
     val gameId: Int,
+    val gameName: String,
     val userId: String,
-    val windowStart: ZonedDateTime,
-    val windowClose: ZonedDateTime,
-    val guessesClose: ZonedDateTime
+    val windowStart: String,
+    val windowClose: String,
+    val guessesClose: String,
 )
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
@@ -1,0 +1,58 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import com.zoho.hawking.HawkingTimeParser
+import com.zoho.hawking.datetimeparser.configuration.HawkingConfiguration
+import com.zoho.hawking.language.english.model.DatesFound
+import dev.kord.core.entity.Member
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
+import java.time.ZoneId
+import java.util.*
+
+class GameUpsertService {
+    fun createGame(userGameName: String?, startWindow: String, closeWindow: String, guessesClose: String,
+                   userId: String, member: Member?, username: String): String {
+        try {
+            val parser = HawkingTimeParser()
+            val referenceDate = Date()
+            val hawkingConfiguration = HawkingConfiguration()
+            hawkingConfiguration.timeZone = ZoneId.systemDefault().toString()
+
+            val startDates: DatesFound = parser.parse(startWindow, referenceDate, hawkingConfiguration, "eng")
+            val closeDates: DatesFound = parser.parse(closeWindow, referenceDate, hawkingConfiguration, "eng")
+            val guessesCloseDates: DatesFound = parser.parse(guessesClose, referenceDate, hawkingConfiguration, "eng")
+
+
+            // Start or end doesn't matter if we only have one date at a time
+            val startDate = startDates.parserOutputs[0].dateRange.start
+            val closeDate = closeDates.parserOutputs[0].dateRange.start
+            val guessesCloseDate = guessesCloseDates.parserOutputs[0].dateRange.start
+            val gameName = userGameName ?: "Game"
+
+            val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+
+            val gameNameString = gameNameStringMaker(gameName, member, username)
+            val startDateString = startDate.toString(dtf)
+            val closeDateString = closeDate.toString(dtf)
+            val guessesCloseDateString = guessesCloseDate.toString(dtf)
+
+            // TODO GameDao connection? Actually saving the data?
+
+            return gameNameString + " : package arriving between " + startDateString + " and " + closeDateString +
+                    ". Guesses accepted until " + guessesCloseDateString
+        } catch (e: Exception) {
+            // TODO logging
+            return "An error has occurred, please re-check your inputs and try again"
+        }
+    }
+
+    private fun gameNameStringMaker(gameName: String?, member: Member?, username: String): String {
+        if(member != null) {
+            return "$gameName by ${member.mention}"
+        } else {
+            // We need username for non-server users that are using this command, if any (hence the nullable Member)
+            // Kinda unlikely, but putting this here just in case
+            return "$gameName by $username"
+        }
+    }
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
@@ -4,6 +4,8 @@ import com.zoho.hawking.HawkingTimeParser
 import com.zoho.hawking.datetimeparser.configuration.HawkingConfiguration
 import com.zoho.hawking.language.english.model.DatesFound
 import dev.kord.core.entity.Member
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatter
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
@@ -12,25 +14,28 @@ import java.time.ZoneId
 import java.util.*
 
 class GameUpsertService(private val gameDao: GameDao) {
+
+    private val parser = HawkingTimeParser()
+    private val referenceDate = Date()
+    private val hawkingConfiguration = HawkingConfiguration()
+    private val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+
+    init {
+        hawkingConfiguration.timeZone = ZoneId.systemDefault().toString()
+    }
+
     fun createGame(userGameName: String?, startWindow: String, closeWindow: String, guessesClose: String,
                    userId: String, member: Member?, username: String): String {
         try {
-            val parser = HawkingTimeParser()
-            val referenceDate = Date()
-            val hawkingConfiguration = HawkingConfiguration()
-            hawkingConfiguration.timeZone = ZoneId.systemDefault().toString()
-
-            val startDates: DatesFound = parser.parse(startWindow, referenceDate, hawkingConfiguration, "eng")
-            val closeDates: DatesFound = parser.parse(closeWindow, referenceDate, hawkingConfiguration, "eng")
-            val guessesCloseDates: DatesFound = parser.parse(guessesClose, referenceDate, hawkingConfiguration, "eng")
+            val startDates: DatesFound = parseDate(startWindow)
+            val closeDates: DatesFound = parseDate(closeWindow)
+            val guessesCloseDates: DatesFound = parseDate(guessesClose)
 
             // Start or end doesn't matter if we only have one date at a time
             val startDate = startDates.parserOutputs[0].dateRange.start
             val closeDate = closeDates.parserOutputs[0].dateRange.start
             val guessesCloseDate = guessesCloseDates.parserOutputs[0].dateRange.start
             val gameName = userGameName ?: "Game"
-
-            val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
 
             val gameNameString = gameNameStringMaker(gameName, member, username)
             val startDateString = startDate.toString(dtf)
@@ -56,6 +61,46 @@ class GameUpsertService(private val gameDao: GameDao) {
             // TODO logging
             return "An error has occurred, please re-check your inputs and try again"
         }
+    }
+
+    fun updateGame(gameId: Int, startWindow: String?, closeWindow: String?, guessesClose: String?): Array<String> {
+        try {
+            gameDao.findActiveGameById(gameId)
+                ?: return arrayOf("Wrong Game ID, please check your gameId input and try again")
+
+            val startDates: DatesFound? = startWindow?.let { parseDate(startWindow) }
+            val closeDates: DatesFound? = closeWindow?.let { parseDate(closeWindow) }
+            val guessesCloseDates: DatesFound? = guessesClose?.let { parseDate(guessesClose) }
+
+            val startDate = startDates?.let { startDates.parserOutputs[0].dateRange.start }
+            val closeDate = closeDates?.let { closeDates.parserOutputs[0].dateRange.start }
+            val guessesCloseDate = guessesCloseDates?.let { guessesCloseDates.parserOutputs[0].dateRange.start }
+
+            val updatedGame: Game = gameDao.updateGameTimes(gameId,
+                startDate?.let { startDate.toGregorianCalendar().toZonedDateTime() },
+                closeDate?.let { closeDate.toGregorianCalendar().toZonedDateTime() },
+                guessesCloseDate?.let { guessesCloseDate.toGregorianCalendar().toZonedDateTime() })
+
+            val startDateString = DateTime(updatedGame.windowStart.toInstant().toEpochMilli(),
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(updatedGame.windowStart.zone))).toString(dtf)
+            val closeDateString = DateTime(updatedGame.windowClose.toInstant().toEpochMilli(),
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(updatedGame.windowClose.zone))).toString(dtf)
+            val guessesCloseDateString = DateTime(updatedGame.guessesClose.toInstant().toEpochMilli(),
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(updatedGame.guessesClose.zone))).toString(dtf)
+
+            val gameUpdatedString: String = "Game #" + gameId + " updated: package now arriving between " + startDateString +
+                    " and " + closeDateString + ". Guesses accepted until " + guessesCloseDateString
+            // TODO respond with member mentions by getting the user id from guesses?
+            return arrayOf(gameUpdatedString)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            // TODO logging
+            return arrayOf("An error has occurred, please re-check your inputs and try again")
+        }
+    }
+
+    private fun parseDate(dateString: String): DatesFound {
+        return parser.parse(dateString, referenceDate, hawkingConfiguration, "eng")
     }
 
     private fun gameNameStringMaker(gameName: String?, member: Member?, username: String): String {

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
@@ -59,6 +59,7 @@ class GameUpsertService(private val gameDao: GameDao) {
                     ". Guesses accepted until " + guessesCloseDateString
         } catch (e: Exception) {
             // TODO logging
+            e.printStackTrace()
             return "An error has occurred, please re-check your inputs and try again"
         }
     }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
@@ -44,7 +44,7 @@ fun setUpDatabaseTables(jdbi: Jdbi) {
         """.trimIndent())
         batch.add("""
             CREATE TABLE GAME (
-                gameId uuid not null,
+                gameId SERIAL PRIMARY KEY,
                 gameName VARCHAR(50) not null,
                 windowStart VARCHAR(50) not null,
                 windowClose VARCHAR(50) not null,

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
@@ -36,20 +36,21 @@ fun setUpDatabaseTables(jdbi: Jdbi) {
         val batch: Batch = it.createBatch()
         batch.add("""
             CREATE TABLE GUESS (
-               guessId uuid not null,
-               gameId uuid not null,
+               guessId SERIAL PRIMARY KEY,
+               gameId INT not null,
                userId VARCHAR(50) not null,
-               guessTime VARCHAR(50) not null
+               guessTime TIMESTAMPTZ not null,
+               CONSTRAINT game_and_guess_time UNIQUE (gameId, guessTime)
             )
         """.trimIndent())
         batch.add("""
             CREATE TABLE GAME (
                 gameId SERIAL PRIMARY KEY,
                 gameName VARCHAR(50) not null,
-                windowStart VARCHAR(50) not null,
-                windowClose VARCHAR(50) not null,
-                guessesClose VARCHAR(50) not null,
-                deliveryTime VARCHAR(50) null,
+                windowStart TIMESTAMPTZ not null,
+                windowClose TIMESTAMPTZ not null,
+                guessesClose TIMESTAMPTZ not null,
+                deliveryTime TIMESTAMPTZ null,
                 userId VARCHAR(50) not null,
                 gameActive BOOLEAN not null
             )

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
@@ -64,6 +64,27 @@ class GameDaoTest {
         assertEquals(createdGame.windowStart, updatedGame.windowStart)
     }
 
+    @DisplayName("findActiveGamesByUserId() will return list of games by user id")
+    @Test
+    fun canSuccessfullyFindActiveGamesByUserId() {
+        val expected = Game(
+            gameId = 2,
+            gameName = "A second game",
+            windowStart = ZonedDateTime.parse("2023-04-10T10:00:00.000Z[Europe/London]"),
+            windowClose = ZonedDateTime.parse("2023-04-10T18:00:00.000Z[Europe/London]"),
+            guessesClose = ZonedDateTime.parse("2023-04-10T08:00:00.000Z[Europe/London]"),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
+        target.createGame(expected)
+
+        val games: List<Game> = target.findActiveGamesByUserId("Z")
+
+        assertEquals(games[0], createdGame)
+        assertEquals(games[1], expected)
+    }
+
     @DisplayName("finishGame() will successfully update the game deliveryTime and gameActive to false")
     @Test
     fun canSuccessfullyFinishGame() {

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
@@ -36,13 +36,6 @@ class GameDaoTest {
         assertEquals(result, createdGame)
     }
 
-    @DisplayName("findActiveGameByName() will successfully return a game by name")
-    @Test
-    fun canSuccessfullyFindActiveGameByName() {
-        val searchedGame: Game = target.findActiveGameByName("random")
-        assertEquals(createdGame, searchedGame)
-    }
-
     @DisplayName("findActiveGameById() will successfully return a game by id")
     @Test
     fun canSuccessfullyFindActiveGameById() {
@@ -70,7 +63,47 @@ class GameDaoTest {
         assertEquals(createdGame.windowStart, updatedGame.windowStart)
     }
 
-    @DisplayName("findActiveGamesByUserId() will return list of games by user id")
+    @DisplayName("finishGame() will successfully update the game deliveryTime and gameActive to false")
+    @Test
+    fun canSuccessfullyFinishGame() {
+        val secondCreatedGame = Game(
+            gameId = 2,
+            gameName = "A second game",
+            windowStart = ZonedDateTime.parse("2023-04-10T10:00:00.000Z[Europe/London]"),
+            windowClose = ZonedDateTime.parse("2023-04-10T18:00:00.000Z[Europe/London]"),
+            guessesClose = ZonedDateTime.parse("2023-04-10T08:00:00.000Z[Europe/London]"),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
+        target.createGame(secondCreatedGame)
+
+        val games: List<Game> = target.findActiveGames(null, null)
+
+        assertEquals(createdGame, games[0])
+        assertEquals(secondCreatedGame, games[1])
+    }
+
+
+    @DisplayName("findActiveGames() with name will successfully return a game by name")
+    @Test
+    fun canSuccessfullyFindActiveGameByName() {
+        val searchedGame: List<Game> = target.findActiveGames("random", null)
+        assertEquals(createdGame, searchedGame[0])
+    }
+
+    @DisplayName("findActiveGame() with null params will successfully get all active games")
+    @Test
+    fun canSuccessfullyFindActiveGames() {
+        val finishedGame: Game = target.finishGame(1,
+            ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
+
+        assertEquals(finishedGame.deliveryTime, ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
+        assertEquals(finishedGame.gameActive, false)
+    }
+
+
+    @DisplayName("findActiveGames() with userId param will return list of games by user id")
     @Test
     fun canSuccessfullyFindActiveGamesByUserId() {
         val expected = Game(
@@ -85,20 +118,10 @@ class GameDaoTest {
         )
         target.createGame(expected)
 
-        val games: List<Game> = target.findActiveGamesByUserId("Z")
+        val games: List<Game> = target.findActiveGames(null, "Z")
 
         assertEquals(games[0], createdGame)
         assertEquals(games[1], expected)
-    }
-
-    @DisplayName("finishGame() will successfully update the game deliveryTime and gameActive to false")
-    @Test
-    fun canSuccessfullyFinishGame() {
-        val finishedGame: Game = target.finishGame(1,
-            ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
-
-        assertEquals(finishedGame.deliveryTime, ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
-        assertEquals(finishedGame.gameActive, false)
     }
 
     private fun createGame(): Game {

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
@@ -12,11 +12,13 @@ import kotlin.test.assertEquals
 class GameDaoTest {
     private lateinit var target: GameDao
     private lateinit var testWrapper: DaoTestWrapper
+    private lateinit var createdGame: Game
 
     @BeforeEach
     fun setUp() {
         testWrapper = initTests()
         target = testWrapper.buildDao(GameDao::class.java)
+        createdGame = createGame()
     }
 
     @AfterEach
@@ -27,26 +29,53 @@ class GameDaoTest {
     @DisplayName("createGame() will successfully insert a game into the table")
     @Test
     fun canSuccessfullyInsertIntoTable() {
-        val createdGame: Game = createGame();
-
         val result = testWrapper.executeSimpleQuery<Game>(
             """SELECT * FROM GAME""".trimIndent()
         )
         assertEquals(result, createdGame)
     }
 
-    @DisplayName("createGame() will successfully insert a game into the table")
+    @DisplayName("findActiveGameByName() will successfully return a game by name")
     @Test
     fun canSuccessfullyFindActiveGameByName() {
-        val createdGame: Game = createGame();
+        val searchedGame: Game = target.findActiveGameByName("random")
+        assertEquals(createdGame, searchedGame)
+    }
 
-        val searchedGame: Game = target.findActiveGameByName("random");
+    @DisplayName("findActiveGameById() will successfully return a game by id")
+    @Test
+    fun canSuccessfullyFindActiveGameById() {
+        val searchedGame: Game = target.findActiveGameById(1)
+        assertEquals(createdGame, searchedGame)
+    }
 
-        assertEquals(createdGame, searchedGame);
+    @DisplayName("updateGameTimes() will successfully update the game time if not null")
+    @Test
+    fun canSuccessfullyUpdateGameTimes() {
+        target.updateGameTimes(1, null, null,
+            ZonedDateTime.parse("2023-04-07T13:00:00.000Z[Europe/London]"))
+
+        val updatedGame: Game = target.findActiveGameById(1)
+        // Guesses close should be updated..
+        assertEquals(updatedGame.guessesClose, ZonedDateTime.parse("2023-04-07T13:00:00.000Z[Europe/London]"))
+
+        // While others are not since it was null in the params
+        assertEquals(createdGame.windowClose, updatedGame.windowClose)
+        assertEquals(createdGame.windowStart, updatedGame.windowStart)
+    }
+
+    @DisplayName("finishGame() will successfully update the game deliveryTime and gameActive to false")
+    @Test
+    fun canSuccessfullyFinishGame() {
+        val finishedGame: Game = target.finishGame(1,
+            ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
+
+        assertEquals(finishedGame.deliveryTime, ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
+        assertEquals(finishedGame.gameActive, false)
     }
 
     private fun createGame(): Game {
-        val gameName = "A random game name for test";
+        val gameName = "A random game name for test"
 
         val expected = Game(
             gameId = 1,
@@ -60,7 +89,7 @@ class GameDaoTest {
         )
         target.createGame(expected)
 
-        return expected;
+        return expected
     }
 
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
@@ -8,6 +8,7 @@ import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
 import java.time.ZonedDateTime
 import java.util.*
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class GameDaoTest {
     private lateinit var target: GameDao
@@ -45,17 +46,22 @@ class GameDaoTest {
     @DisplayName("findActiveGameById() will successfully return a game by id")
     @Test
     fun canSuccessfullyFindActiveGameById() {
-        val searchedGame: Game = target.findActiveGameById(1)
+        val searchedGame: Game? = target.findActiveGameById(1)
         assertEquals(createdGame, searchedGame)
+    }
+
+    @DisplayName("findActiveGameById() will return null on unknown gameId")
+    @Test
+    fun getNullOnWrongGameIdInFindActiveGameById() {
+        val searchedGame: Game? = target.findActiveGameById(999)
+        assertNull(searchedGame)
     }
 
     @DisplayName("updateGameTimes() will successfully update the game time if not null")
     @Test
     fun canSuccessfullyUpdateGameTimes() {
-        target.updateGameTimes(1, null, null,
+        val updatedGame: Game = target.updateGameTimes(1, null, null,
             ZonedDateTime.parse("2023-04-07T13:00:00.000Z[Europe/London]"))
-
-        val updatedGame: Game = target.findActiveGameById(1)
         // Guesses close should be updated..
         assertEquals(updatedGame.guessesClose, ZonedDateTime.parse("2023-04-07T13:00:00.000Z[Europe/London]"))
 

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
@@ -46,11 +46,10 @@ class GameDaoTest {
     }
 
     private fun createGame(): Game {
-        val gameId = UUID.randomUUID()
         val gameName = "A random game name for test";
 
         val expected = Game(
-            gameId = gameId,
+            gameId = 1,
             gameName = gameName,
             windowStart = ZonedDateTime.parse("2023-04-07T09:00:00.000Z[Europe/London]"),
             windowClose = ZonedDateTime.parse("2023-04-07T17:00:00.000Z[Europe/London]"),

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderServiceTest.kt
@@ -1,0 +1,59 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
+import java.time.ZonedDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GameFinderServiceTest {
+    private lateinit var target: GameFinderService
+    private val expectedGame: Game = getGameStub()
+
+    @BeforeEach
+    fun setUp() {
+        val gameDao = mockk<GameDao>()
+        every {gameDao.findActiveGameById(any())} returns expectedGame
+        every {gameDao.findActiveGames(any(), any()) } returns listOf(expectedGame)
+        target = GameFinderService(gameDao)
+    }
+
+    @DisplayName("findGames() with gameId param will return a game after searched using gameId")
+    @Test
+    fun returnListOfResponseWhenSearchingWithGameId() {
+        val returnedList = target.findGames(null, null, 1)
+        assertEquals(returnedList[0].gameId, expectedGame.gameId)
+        assertEquals(returnedList[0].userId, expectedGame.userId)
+        assertEquals(returnedList[0].windowStart, expectedGame.windowStart)
+        assertEquals(returnedList[0].windowClose, expectedGame.windowClose)
+        assertEquals(returnedList[0].guessesClose, expectedGame.guessesClose)
+    }
+
+    @DisplayName("findGames() with gameName / userId param will return searched game")
+    @Test
+    fun returnListOfResponseWhenSearchingWithGameNameAndOrUserId() {
+        val returnedList = target.findGames("Z", "testing", null)
+        assertEquals(returnedList[0].gameId, expectedGame.gameId)
+        assertEquals(returnedList[0].userId, expectedGame.userId)
+        assertEquals(returnedList[0].windowStart, expectedGame.windowStart)
+        assertEquals(returnedList[0].windowClose, expectedGame.windowClose)
+        assertEquals(returnedList[0].guessesClose, expectedGame.guessesClose)
+    }
+
+    private fun getGameStub(): Game {
+        return Game(
+            gameId = 1,
+            gameName = "Testing testing",
+            windowStart = ZonedDateTime.now().withHour(15).withMinute(0),
+            windowClose = ZonedDateTime.now().withHour(19).withMinute(0),
+            guessesClose = ZonedDateTime.now().withHour(14).withMinute(0),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
+    }
+}

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderServiceTest.kt
@@ -2,17 +2,23 @@ package uk.co.mutuallyassureddistraction.paketliga.matching
 
 import io.mockk.every
 import io.mockk.mockk
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
 import java.time.ZonedDateTime
+import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class GameFinderServiceTest {
     private lateinit var target: GameFinderService
     private val expectedGame: Game = getGameStub()
+    private val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
 
     @BeforeEach
     fun setUp() {
@@ -28,9 +34,9 @@ class GameFinderServiceTest {
         val returnedList = target.findGames(null, null, 1)
         assertEquals(returnedList[0].gameId, expectedGame.gameId)
         assertEquals(returnedList[0].userId, expectedGame.userId)
-        assertEquals(returnedList[0].windowStart, expectedGame.windowStart)
-        assertEquals(returnedList[0].windowClose, expectedGame.windowClose)
-        assertEquals(returnedList[0].guessesClose, expectedGame.guessesClose)
+        assertEquals(returnedList[0].windowStart, zonedDateTimeToString(expectedGame.windowStart))
+        assertEquals(returnedList[0].windowClose, zonedDateTimeToString(expectedGame.windowClose))
+        assertEquals(returnedList[0].guessesClose, zonedDateTimeToString(expectedGame.guessesClose))
     }
 
     @DisplayName("findGames() with gameName / userId param will return searched game")
@@ -39,9 +45,14 @@ class GameFinderServiceTest {
         val returnedList = target.findGames("Z", "testing", null)
         assertEquals(returnedList[0].gameId, expectedGame.gameId)
         assertEquals(returnedList[0].userId, expectedGame.userId)
-        assertEquals(returnedList[0].windowStart, expectedGame.windowStart)
-        assertEquals(returnedList[0].windowClose, expectedGame.windowClose)
-        assertEquals(returnedList[0].guessesClose, expectedGame.guessesClose)
+        assertEquals(returnedList[0].windowStart, zonedDateTimeToString(expectedGame.windowStart))
+        assertEquals(returnedList[0].windowClose, zonedDateTimeToString(expectedGame.windowClose))
+        assertEquals(returnedList[0].guessesClose,zonedDateTimeToString(expectedGame.guessesClose))
+    }
+
+    private fun zonedDateTimeToString(dtz : ZonedDateTime): String {
+        return DateTime(dtz.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(dtz.zone))).toString(dtf)
     }
 
     private fun getGameStub(): Game {

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameResultResolverTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameResultResolverTest.kt
@@ -85,7 +85,7 @@ class GameResultResolverTest {
 
     private fun buildGame(): Game {
         return Game(
-            gameId = UUID.randomUUID(),
+            gameId = 1,
             gameName = "Testing testing",
             windowStart = ZonedDateTime.now(),
             windowClose = ZonedDateTime.now(),

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameResultResolverTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameResultResolverTest.kt
@@ -76,8 +76,8 @@ class GameResultResolverTest {
 
     private fun buildGuess(guessTime: String): Guess {
         return Guess(
-            guessId = UUID.randomUUID(),
-            gameId = UUID.randomUUID(),
+            guessId = 1,
+            gameId = 1,
             userId = "PostMasterGeneral",
             guessTime = ZonedDateTime.parse(guessTime)
         )

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
@@ -9,18 +9,25 @@ import org.joda.time.format.DateTimeFormatter
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
+import java.time.ZonedDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class GameUpsertServiceTest {
 
     private lateinit var target: GameUpsertService
+    private lateinit var dtf: DateTimeFormatter
 
     @BeforeEach
     fun setUp() {
         val gameDao = mockk<GameDao>()
         every {gameDao.createGame(any())} returns Unit
+        every {gameDao.findActiveGameById(999)} returns null
+        every {gameDao.findActiveGameById(1)} returns mockk<Game>()
+        every {gameDao.updateGameTimes(any(), any(), any(), any())} returns getUpdatedGameStub()
         target = GameUpsertService(gameDao)
+        dtf = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
     }
 
     @DisplayName("createGame() will return string with gameName and member mentioned if both values are not null")
@@ -31,7 +38,7 @@ class GameUpsertServiceTest {
         val gameName = "Random Amazon package"
         val returnedString = target.createGame(gameName, "today 2pm",
             "today 7pm", "today 1pm", "1234", member, "ZLX")
-        val expectedString = getExpectedString(gameName, member, "ZLX")
+        val expectedString = getCreateGameExpectedString(gameName, member, "ZLX")
         assertEquals(expectedString, returnedString)
     }
 
@@ -40,13 +47,49 @@ class GameUpsertServiceTest {
     fun returnStringWithNullGameNameAndMember() {
         val returnedString = target.createGame(null, "today 2pm",
             "today 7pm", "today 1pm", "1234", null, "ZLX")
-        val expectedString = getExpectedString(null, null, "ZLX")
+        val expectedString = getCreateGameExpectedString(null, null, "ZLX")
         assertEquals(returnedString, expectedString)
     }
 
-    private fun getExpectedString(userGameName: String?, member: Member?, username: String): String {
-        val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+    @DisplayName("updateGame() will return wrong Game ID string")
+    @Test
+    fun returnStringWithWrongGameIDInformation() {
+        target.createGame(null, "today 2pm",
+            "today 7pm", "today 1pm", "1234", null, "ZLX")
+        val returnedString = target.updateGame(999, null, null, null)
+        val expectedString = "Wrong Game ID, please check your gameId input and try again"
+        assertEquals(returnedString[0], expectedString)
+    }
 
+    @DisplayName("updateGame() will return updated game string")
+    @Test
+    fun returnStringWithUpdatedGameInfo() {
+        target.createGame(null, "today 2pm",
+            "today 7pm", "today 1pm", "1234", null, "ZLX")
+        val returnedString = target.updateGame(1, "today 3 pm", null, "today 2 pm")
+
+        val startTime = LocalDateTime.now().withHourOfDay(15).withMinuteOfHour(0).toString(dtf)
+        val closeTime = LocalDateTime.now().withHourOfDay(19).withMinuteOfHour(0).toString(dtf)
+        val guessesCloseTime = LocalDateTime.now().withHourOfDay(14).withMinuteOfHour(0).toString(dtf)
+        val expectedString = "Game #1 updated: package now arriving between " + startTime +
+                " and " + closeTime + ". Guesses accepted until " + guessesCloseTime
+        assertEquals(returnedString[0], expectedString)
+    }
+
+    private fun getUpdatedGameStub(): Game {
+        return Game(
+            gameId = 1,
+            gameName = "Testing testing",
+            windowStart = ZonedDateTime.now().withHour(15).withMinute(0),
+            windowClose = ZonedDateTime.now().withHour(19).withMinute(0),
+            guessesClose = ZonedDateTime.now().withHour(14).withMinute(0),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
+    }
+
+    private fun getCreateGameExpectedString(userGameName: String?, member: Member?, username: String): String {
         val startTime = LocalDateTime.now().withHourOfDay(14).withMinuteOfHour(0).toString(dtf)
         val closeTime = LocalDateTime.now().withHourOfDay(19).withMinuteOfHour(0).toString(dtf)
         val guessesCloseTime = LocalDateTime.now().withHourOfDay(13).withMinuteOfHour(0).toString(dtf)

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
@@ -1,0 +1,55 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import dev.kord.core.entity.Member
+import io.mockk.every
+import io.mockk.mockk
+import org.joda.time.LocalDate
+import org.joda.time.LocalDateTime
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
+import org.junit.jupiter.api.DisplayName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GameUpsertServiceTest {
+    private val target = GameUpsertService()
+
+    @DisplayName("createGame() will return string with gameName and member mentioned if both values are not null")
+    @Test
+    fun returnStringWithNonNullGameNameAndMember() {
+        val member = mockk<Member>()
+        every {member.mention} returns "Z"
+        val gameName = "Random Amazon package"
+        val returnedString = target.createGame(gameName, "2pm",
+            "7pm", "1pm", "1234", member, "ZLX")
+        val expectedString = getExpectedString(gameName, member, "ZLX")
+        assertEquals(returnedString, expectedString)
+    }
+
+    @DisplayName("createGame() will return string with default 'Game' string and username if game name and member are null")
+    @Test
+    fun returnStringWithNullGameNameAndMember() {
+        val returnedString = target.createGame(null, "2pm",
+            "7pm", "1pm", "1234", null, "ZLX")
+        val expectedString = getExpectedString(null, null, "ZLX")
+        assertEquals(returnedString, expectedString)
+    }
+
+    private fun getExpectedString(userGameName: String?, member: Member?, username: String): String {
+        val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+
+        val startTime = LocalDateTime.now().withHourOfDay(14).withMinuteOfHour(0).toString(dtf)
+        val closeTime = LocalDateTime.now().withHourOfDay(19).withMinuteOfHour(0).toString(dtf)
+        val guessesCloseTime = LocalDateTime.now().withHourOfDay(13).withMinuteOfHour(0).toString(dtf)
+
+        val gameName = userGameName ?: "Game"
+
+        if(member != null) {
+            return "$gameName by ${member.mention}" + " : package arriving between " + startTime + " and " + closeTime +
+                    ". Guesses accepted until " + guessesCloseTime
+        } else {
+            return "$gameName by $username" + " : package arriving between " + startTime + " and " + closeTime +
+                    ". Guesses accepted until " + guessesCloseTime
+        }
+    }
+}

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
@@ -3,16 +3,25 @@ package uk.co.mutuallyassureddistraction.paketliga.matching
 import dev.kord.core.entity.Member
 import io.mockk.every
 import io.mockk.mockk
-import org.joda.time.LocalDate
 import org.joda.time.LocalDateTime
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatter
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class GameUpsertServiceTest {
-    private val target = GameUpsertService()
+
+    private lateinit var target: GameUpsertService
+
+    @BeforeEach
+    fun setUp() {
+        val gameDao = mockk<GameDao>()
+        every {gameDao.createGame(any())} returns Unit
+        target = GameUpsertService(gameDao)
+    }
 
     @DisplayName("createGame() will return string with gameName and member mentioned if both values are not null")
     @Test
@@ -44,11 +53,11 @@ class GameUpsertServiceTest {
 
         val gameName = userGameName ?: "Game"
 
-        if(member != null) {
-            return "$gameName by ${member.mention}" + " : package arriving between " + startTime + " and " + closeTime +
+        return if(member != null) {
+            "$gameName by ${member.mention}" + " : package arriving between " + startTime + " and " + closeTime +
                     ". Guesses accepted until " + guessesCloseTime
         } else {
-            return "$gameName by $username" + " : package arriving between " + startTime + " and " + closeTime +
+            "$gameName by $username" + " : package arriving between " + startTime + " and " + closeTime +
                     ". Guesses accepted until " + guessesCloseTime
         }
     }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
@@ -20,17 +20,17 @@ class GameUpsertServiceTest {
         val member = mockk<Member>()
         every {member.mention} returns "Z"
         val gameName = "Random Amazon package"
-        val returnedString = target.createGame(gameName, "2pm",
-            "7pm", "1pm", "1234", member, "ZLX")
+        val returnedString = target.createGame(gameName, "today 2pm",
+            "today 7pm", "today 1pm", "1234", member, "ZLX")
         val expectedString = getExpectedString(gameName, member, "ZLX")
-        assertEquals(returnedString, expectedString)
+        assertEquals(expectedString, returnedString)
     }
 
     @DisplayName("createGame() will return string with default 'Game' string and username if game name and member are null")
     @Test
     fun returnStringWithNullGameNameAndMember() {
-        val returnedString = target.createGame(null, "2pm",
-            "7pm", "1pm", "1234", null, "ZLX")
+        val returnedString = target.createGame(null, "today 2pm",
+            "today 7pm", "today 1pm", "1234", null, "ZLX")
         val expectedString = getExpectedString(null, null, "ZLX")
         assertEquals(returnedString, expectedString)
     }


### PR DESCRIPTION
(This PR is dependent on https://github.com/OhDearMoshe/pkl/pull/17, see only commit 75f513acb7d5457fab495b6b88ac8fee4a9e70e3)

Added Constraint to Guess columns by making composite unique columns: `gameid` and `guesstime`. This way we don't really have to handle duplicate time when inserting guesses and just have to catch the errors.

The PR also changed Guess primary key to using serial instead of UUID (RFC, not necessarily have to be serial though, just for convenience)

Also fixed some tests that were failing.

```
./gradlew build
BUILD SUCCESSFUL in 36s
7 actionable tasks: 6 executed, 1 up-to-date
```