### PR TITLE
Added Point DAO and Win DAO with tests

### DIFF
--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -17,7 +17,7 @@ import uk.co.mutuallyassureddistraction.paketliga.extensions.GuessGameExtension
 import uk.co.mutuallyassureddistraction.paketliga.extensions.UpdateGameExtension
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameFinderService
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
-import uk.co.mutuallyassureddistraction.paketliga.matching.GuessService
+import uk.co.mutuallyassureddistraction.paketliga.matching.GuessUpsertService
 import java.sql.Connection
 import java.sql.DriverManager
 
@@ -40,12 +40,12 @@ suspend fun main() {
         val guessDao = jdbi.onDemand<GuessDao>()
         val gameUpsertService = GameUpsertService(gameDao)
         val gameFinderService = GameFinderService(gameDao)
-        val guessService = GuessService(guessDao)
+        val guessUpsertService = GuessUpsertService(guessDao)
 
         val createGameExtension = CreateGameExtension(gameUpsertService, SERVER_ID)
         val updateGameExtension = UpdateGameExtension(gameUpsertService, SERVER_ID)
         val findGamesExtension = FindGamesExtension(gameFinderService, SERVER_ID)
-        val guessGameExtension = GuessGameExtension(guessService, SERVER_ID)
+        val guessGameExtension = GuessGameExtension(guessUpsertService, SERVER_ID)
 
         val bot = ExtensibleBot(BOT_TOKEN) {
             chatCommands {

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -11,12 +11,10 @@ import org.jdbi.v3.sqlobject.kotlin.KotlinSqlObjectPlugin
 import org.jdbi.v3.sqlobject.kotlin.onDemand
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import uk.co.mutuallyassureddistraction.paketliga.dao.GuessDao
-import uk.co.mutuallyassureddistraction.paketliga.extensions.CreateGameExtension
-import uk.co.mutuallyassureddistraction.paketliga.extensions.FindGamesExtension
-import uk.co.mutuallyassureddistraction.paketliga.extensions.GuessGameExtension
-import uk.co.mutuallyassureddistraction.paketliga.extensions.UpdateGameExtension
+import uk.co.mutuallyassureddistraction.paketliga.extensions.*
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameFinderService
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
+import uk.co.mutuallyassureddistraction.paketliga.matching.GuessFinderService
 import uk.co.mutuallyassureddistraction.paketliga.matching.GuessUpsertService
 import java.sql.Connection
 import java.sql.DriverManager
@@ -41,11 +39,13 @@ suspend fun main() {
         val gameUpsertService = GameUpsertService(gameDao)
         val gameFinderService = GameFinderService(gameDao)
         val guessUpsertService = GuessUpsertService(guessDao)
+        val guessFinderService = GuessFinderService(guessDao)
 
         val createGameExtension = CreateGameExtension(gameUpsertService, SERVER_ID)
         val updateGameExtension = UpdateGameExtension(gameUpsertService, SERVER_ID)
         val findGamesExtension = FindGamesExtension(gameFinderService, SERVER_ID)
         val guessGameExtension = GuessGameExtension(guessUpsertService, SERVER_ID)
+        val findGuessExtension = FindGuessExtension(guessFinderService, SERVER_ID)
 
         val bot = ExtensibleBot(BOT_TOKEN) {
             chatCommands {
@@ -58,6 +58,7 @@ suspend fun main() {
                 add { updateGameExtension }
                 add { findGamesExtension }
                 add { guessGameExtension }
+                add { findGuessExtension }
             }
         }
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -11,7 +11,9 @@ import org.jdbi.v3.sqlobject.kotlin.KotlinSqlObjectPlugin
 import org.jdbi.v3.sqlobject.kotlin.onDemand
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import uk.co.mutuallyassureddistraction.paketliga.extensions.CreateGameExtension
+import uk.co.mutuallyassureddistraction.paketliga.extensions.FindGamesExtension
 import uk.co.mutuallyassureddistraction.paketliga.extensions.UpdateGameExtension
+import uk.co.mutuallyassureddistraction.paketliga.matching.GameFinderService
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 import java.sql.Connection
 import java.sql.DriverManager
@@ -33,9 +35,11 @@ suspend fun main() {
         // initialise GameDao and GameExtension
         val gameDao = jdbi.onDemand<GameDao>()
         val gameUpsertService = GameUpsertService(gameDao)
+        val gameFinderService = GameFinderService(gameDao)
 
         val createGameExtension = CreateGameExtension(gameUpsertService, SERVER_ID)
         val updateGameExtension = UpdateGameExtension(gameUpsertService, SERVER_ID)
+        val findGamesExtension = FindGamesExtension(gameFinderService, SERVER_ID)
 
         val bot = ExtensibleBot(BOT_TOKEN) {
             chatCommands {
@@ -46,6 +50,7 @@ suspend fun main() {
             extensions {
                 add { createGameExtension }
                 add { updateGameExtension }
+                add { findGamesExtension }
             }
         }
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -10,11 +10,14 @@ import org.jdbi.v3.sqlobject.SqlObjectPlugin
 import org.jdbi.v3.sqlobject.kotlin.KotlinSqlObjectPlugin
 import org.jdbi.v3.sqlobject.kotlin.onDemand
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.GuessDao
 import uk.co.mutuallyassureddistraction.paketliga.extensions.CreateGameExtension
 import uk.co.mutuallyassureddistraction.paketliga.extensions.FindGamesExtension
+import uk.co.mutuallyassureddistraction.paketliga.extensions.GuessGameExtension
 import uk.co.mutuallyassureddistraction.paketliga.extensions.UpdateGameExtension
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameFinderService
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
+import uk.co.mutuallyassureddistraction.paketliga.matching.GuessService
 import java.sql.Connection
 import java.sql.DriverManager
 
@@ -34,12 +37,15 @@ suspend fun main() {
 
         // initialise GameDao and GameExtension
         val gameDao = jdbi.onDemand<GameDao>()
+        val guessDao = jdbi.onDemand<GuessDao>()
         val gameUpsertService = GameUpsertService(gameDao)
         val gameFinderService = GameFinderService(gameDao)
+        val guessService = GuessService(guessDao)
 
         val createGameExtension = CreateGameExtension(gameUpsertService, SERVER_ID)
         val updateGameExtension = UpdateGameExtension(gameUpsertService, SERVER_ID)
         val findGamesExtension = FindGamesExtension(gameFinderService, SERVER_ID)
+        val guessGameExtension = GuessGameExtension(guessService, SERVER_ID)
 
         val bot = ExtensibleBot(BOT_TOKEN) {
             chatCommands {
@@ -51,6 +57,7 @@ suspend fun main() {
                 add { createGameExtension }
                 add { updateGameExtension }
                 add { findGamesExtension }
+                add { guessGameExtension }
             }
         }
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -29,16 +29,18 @@ interface GameDao {
      """)
      fun createGame(game: Game)
 
-     @SqlUpdate("""
+     @SqlQuery("""
           UPDATE GAME
           SET 
                windowStart = COALESCE(:windowStart, windowStart),
                windowClose = COALESCE(:windowClose, windowClose),
                guessesClose = COALESCE(:guessesClose, windowClose)
           WHERE gameId = :id
+          RETURNING *
      """)
      fun updateGameTimes(@Bind("id")gameId: Int, @Bind("windowStart")windowStart: ZonedDateTime?,
-                         @Bind("windowClose")windowClose: ZonedDateTime?, @Bind("guessesClose")guessesClose: ZonedDateTime)
+                         @Bind("windowClose")windowClose: ZonedDateTime?,
+                         @Bind("guessesClose")guessesClose: ZonedDateTime?): Game
 
      @SqlQuery("""
           UPDATE Game
@@ -62,7 +64,7 @@ interface GameDao {
           WHERE gameId = :id
           AND gameActive = 'TRUE'
      """)
-     fun findActiveGameById(@Bind("id")gameId: Int): Game
+     fun findActiveGameById(@Bind("id")gameId: Int): Game?
 
      @SqlQuery("""
           SELECT * FROM GAME

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -63,4 +63,11 @@ interface GameDao {
           AND gameActive = 'TRUE'
      """)
      fun findActiveGameById(@Bind("id")gameId: Int): Game
+
+     @SqlQuery("""
+          SELECT * FROM GAME
+          WHERE userId = :id
+          AND gameActive = 'TRUE'
+     """)
+     fun findActiveGamesByUserId(@Bind("id")useId: String): List<Game>
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -54,13 +54,6 @@ interface GameDao {
 
      @SqlQuery("""
           SELECT * FROM GAME
-          WHERE gameName LIKE concat('%',:gameName,'%')
-          AND gameActive = 'TRUE'
-     """)
-     fun findActiveGameByName(gameName: String): Game
-
-     @SqlQuery("""
-          SELECT * FROM GAME
           WHERE gameId = :id
           AND gameActive = 'TRUE'
      """)
@@ -68,8 +61,9 @@ interface GameDao {
 
      @SqlQuery("""
           SELECT * FROM GAME
-          WHERE userId = :id
+          WHERE (:gameName IS NULL OR gameName LIKE concat('%',:gameName,'%'))
+          AND (:userId is NULL OR userId = :userId)
           AND gameActive = 'TRUE'
      """)
-     fun findActiveGamesByUserId(@Bind("id")useId: String): List<Game>
+     fun findActiveGames(gameName: String?, userId: String?): List<Game>
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
@@ -9,13 +9,11 @@ import java.util.*
 interface GuessDao {
     @SqlUpdate("""
             INSERT INTO GUESS(
-                guessId,
                 gameId,
                 userId,
                 guessTime
             )
             VALUES (
-                :guess.guessId,
                 :guess.gameId,
                 :guess.userId,
                 :guess.guessTime

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
@@ -32,5 +32,5 @@ interface GuessDao {
                 FROM GUESS
                 WHERE guessId = :id
     """)
-    fun findGuessByGuessId(@Bind("id") guessId: UUID): Guess
+    fun findGuessByGuessId(@Bind("id") guessId: Int): Guess
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
@@ -31,4 +31,10 @@ interface GuessDao {
                 WHERE guessId = :id
     """)
     fun findGuessByGuessId(@Bind("id") guessId: Int): Guess
+
+    @SqlQuery("""
+        SELECT * FROM GUESS
+        WHERE gameId = :id
+    """)
+    fun findGuessesByGameId(@Bind("id") gameId: Int): List<Guess>
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDao.kt
@@ -1,0 +1,57 @@
+package uk.co.mutuallyassureddistraction.paketliga.dao
+
+import org.jdbi.v3.sqlobject.statement.SqlUpdate
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Point
+
+interface PointDao {
+    @SqlUpdate("""
+        INSERT INTO POINT as pnt(
+            userId,
+            played,
+            won,
+            lost,
+            totalPoint
+        )
+        VALUES (
+            :point.userId,
+            :point.played,
+            :point.won,
+            :point.lost,
+            :point.totalPoint
+        )
+        ON CONFLICT (userId) DO UPDATE
+            SET 
+                totalPoint = pnt.totalPoint + 1,
+                won = pnt.won + 1
+            WHERE pnt.userId = :point.userId
+        RETURNING *
+    """)
+    fun addWin(point: Point)
+
+    @SqlUpdate("""
+        INSERT INTO POINT as pnt(
+            userId,
+            played,
+            won,
+            lost,
+            totalPoint
+        )
+        VALUES (
+            :point.userId,
+            :point.played,
+            :point.won,
+            :point.lost,
+            :point.totalPoint
+        )
+        ON CONFLICT (userId) DO UPDATE
+            SET 
+                totalPoint = CASE
+                    WHEN pnt.totalPoint = 0 THEN pnt.totalPoint
+                    ELSE pnt.totalPoint - 1
+                    END,
+                lost = pnt.lost + 1
+            WHERE pnt.userId = :point.userId
+        RETURNING *
+    """)
+    fun addLost(point: Point)
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/WinDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/WinDao.kt
@@ -1,0 +1,21 @@
+package uk.co.mutuallyassureddistraction.paketliga.dao
+
+import org.jdbi.v3.sqlobject.statement.SqlUpdate
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Win
+
+interface WinDao {
+    @SqlUpdate("""
+        INSERT INTO WIN(
+            gameId,
+            guessId,
+            date
+        )
+        VALUES (
+            :winningGuess.gameId,
+            :winningGuess.guessId,
+            :winningGuess.date
+        )
+        RETURNING *
+    """)
+    fun addWinningGuess(winningGuess: Win)
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Guess.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Guess.kt
@@ -1,11 +1,10 @@
 package uk.co.mutuallyassureddistraction.paketliga.dao.entity
 
 import java.time.ZonedDateTime
-import java.util.UUID
 
 data class Guess(
-    val guessId: UUID,
-    val gameId: UUID,
+    val guessId: Int?,
+    val gameId: Int,
     val userId: String,
     val guessTime: ZonedDateTime
 )

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Point.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Point.kt
@@ -1,0 +1,10 @@
+package uk.co.mutuallyassureddistraction.paketliga.dao.entity
+
+data class Point(
+    val pointId: Int?,
+    val userId: String,
+    val played: Int,
+    val won: Int,
+    val lost: Int,
+    val totalPoint: Int,
+)

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Win.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Win.kt
@@ -1,0 +1,10 @@
+package uk.co.mutuallyassureddistraction.paketliga.dao.entity
+
+import java.time.ZonedDateTime
+
+data class Win(
+    val winId: Int?,
+    val gameId: Int,
+    val guessId: Int,
+    val date: ZonedDateTime,
+)

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/CreateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/CreateGameExtension.kt
@@ -6,17 +6,11 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
-import com.kotlindiscord.kord.extensions.utils.env
 import dev.kord.common.entity.Snowflake
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 
-
-val SERVER_ID = Snowflake(
-    env("SERVER_ID").toLong()  // Get the test server ID from the env vars or a .env file
-)
-
-class GameExtension(private val gameUpsertService: GameUpsertService) : Extension() {
-    override val name = "gameExtension"
+class CreateGameExtension(private val gameUpsertService: GameUpsertService, private val serverId: Snowflake) : Extension() {
+    override val name = "createGameExtension"
 
     override suspend fun setup() {
         publicSlashCommand(::PaketGameArgs) {  // Public slash commands have public responses
@@ -24,7 +18,7 @@ class GameExtension(private val gameUpsertService: GameUpsertService) : Extensio
             description = "Ask the bot to create a game of PKL"
 
             // Use guild commands for testing, global ones take up to an hour to update
-            guild(SERVER_ID)
+            guild(serverId)
 
             action {
                 val createGameResponse = gameUpsertService.createGame(

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
@@ -7,6 +7,7 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalUser
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.types.respondEphemeral
 import com.kotlindiscord.kord.extensions.types.respondingPaginator
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.MemberBehavior
@@ -29,37 +30,44 @@ class FindGamesExtension(private val gameFinderService: GameFinderService, priva
                 val gameName = arguments.gamename
                 val userId = arguments.gamecreator?.asUser()?.id?.value?.toString()
 
-                val responseList: List<FindGamesResponse> = gameFinderService.findGames(userId, gameName, gameId)
-
-                val kord = this@FindGamesExtension.kord
-
-                if(responseList.isEmpty()) {
-                    respond {
-                        content = "No games found."
+                if(gameId == null && gameName == null && userId == null) {
+                    respondEphemeral {
+                        content = "No params specified, nothing to be searched."
                     }
                 } else {
-                    val paginator = respondingPaginator {
-                        responseList.chunked(5).map { response ->
-                            val pageFields = ArrayList<EmbedBuilder.Field>()
-                            response.forEach {
-                                val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+                    val responseList: List<FindGamesResponse> = gameFinderService.findGames(userId, gameName, gameId)
 
-                                val field = EmbedBuilder.Field()
-                                field.name = "ID #" + it.gameId.toString() + ": Game by " + memberBehavior.asMember().displayName +
-                                        " - " + it.gameName
-                                field.value = "Arriving between " + it.windowStart + " and " + it.windowClose +
-                                        ".\n Guesses accepted until " + it.guessesClose
-                                pageFields.add(field)
-                            }
+                    val kord = this@FindGamesExtension.kord
 
-                            page {
-                                title = "List of PKL games: "
-                                fields = pageFields
+                    if (responseList.isEmpty()) {
+                        respond {
+                            content = "No games found."
+                        }
+                    } else {
+                        val paginator = respondingPaginator {
+                            responseList.chunked(5).map { response ->
+                                val pageFields = ArrayList<EmbedBuilder.Field>()
+                                response.forEach {
+                                    val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+
+                                    val field = EmbedBuilder.Field()
+                                    field.name =
+                                        "ID #" + it.gameId.toString() + ": Game by " + memberBehavior.asMember().displayName +
+                                                " - " + it.gameName
+                                    field.value = "Arriving between " + it.windowStart + " and " + it.windowClose +
+                                            ".\n Guesses accepted until " + it.guessesClose
+                                    pageFields.add(field)
+                                }
+
+                                page {
+                                    title = "List of PKL games: "
+                                    fields = pageFields
+                                }
                             }
                         }
-                    }
 
-                    paginator.send()
+                        paginator.send()
+                    }
                 }
             }
         }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
@@ -1,0 +1,84 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalInt
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalUser
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.types.respondingPaginator
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.MemberBehavior
+import dev.kord.rest.builder.message.EmbedBuilder
+import uk.co.mutuallyassureddistraction.paketliga.matching.FindGamesResponse
+import uk.co.mutuallyassureddistraction.paketliga.matching.GameFinderService
+
+class FindGamesExtension(private val gameFinderService: GameFinderService, private val serverId: Snowflake) : Extension() {
+    override val name = "findGamesExtension"
+
+    override suspend fun setup() {
+        publicSlashCommand(::FindGamesArgs) {
+            name = "findgames"
+            description = "Ask the bot to find PKL games"
+
+            guild(serverId)
+
+            action {
+                val gameId = arguments.gameid
+                val gameName = arguments.gamename
+                val userId = arguments.gamecreator?.asUser()?.id?.value?.toString()
+
+                val responseList: List<FindGamesResponse> = gameFinderService.findGames(userId, gameName, gameId)
+
+                val kord = this@FindGamesExtension.kord
+
+                if(responseList.isEmpty()) {
+                    respond {
+                        content = "No games found."
+                    }
+                } else {
+                    val paginator = respondingPaginator {
+                        responseList.chunked(5).map { response ->
+                            val pageFields = ArrayList<EmbedBuilder.Field>()
+                            response.forEach {
+                                val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+
+                                val field = EmbedBuilder.Field()
+                                field.name = "ID #" + it.gameId.toString() + ": Game by " + memberBehavior.asMember().displayName +
+                                        " - " + it.gameName
+                                field.value = "Arriving between " + it.windowStart + " and " + it.windowClose +
+                                        ".\n Guesses accepted until " + it.guessesClose
+                                pageFields.add(field)
+                            }
+
+                            page {
+                                title = "List of PKL games: "
+                                fields = pageFields
+                            }
+                        }
+                    }
+
+                    paginator.send()
+                }
+            }
+        }
+    }
+
+    inner class FindGamesArgs : Arguments() {
+        val gamecreator by optionalUser {
+            name = "gamecreator"
+            description = "Creator of the games"
+        }
+
+        val gameid by optionalInt {
+            name = "gameid"
+            description = "ID of the PKL game"
+        }
+
+        val gamename by optionalString {
+            name = "gamename"
+            description = "Name of the game"
+        }
+    }
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGamesExtension.kt
@@ -64,6 +64,9 @@ class FindGamesExtension(private val gameFinderService: GameFinderService, priva
                                     fields = pageFields
                                 }
                             }
+
+                            // This will make the pagination function (next prev etc) to disappear after timeout time
+                            timeoutSeconds = 15L
                         }
 
                         paginator.send()

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGuessExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/FindGuessExtension.kt
@@ -1,0 +1,83 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalInt
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.types.respondEphemeral
+import com.kotlindiscord.kord.extensions.types.respondingPaginator
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.MemberBehavior
+import dev.kord.rest.builder.message.EmbedBuilder
+import uk.co.mutuallyassureddistraction.paketliga.matching.GuessFinderService
+
+class FindGuessExtension(private val guessFinderService: GuessFinderService, private val serverId: Snowflake) : Extension() {
+    override val name = "findGuessExtension"
+    override suspend fun setup() {
+        publicSlashCommand(::FindGuessArgs) {
+            name = "findguess"
+            description = "Ask the bot to find PKL guesses"
+
+            guild(serverId)
+            action {
+                val gameId = arguments.gameid
+                val guessId = arguments.guessid
+
+                if(gameId == null && guessId == null) {
+                    respondEphemeral {
+                        content = "No params specified, nothing to be searched."
+                    }
+                } else {
+                    val responseList: List<GuessFinderService.FindGuessesResponse> = guessFinderService.findGuesses(gameId, guessId)
+
+                    val kord = this@FindGuessExtension.kord
+
+                    if (responseList.isEmpty()) {
+                        respond {
+                            content = "No guesses found."
+                        }
+                    } else {
+                        val paginator = respondingPaginator {
+                            responseList.chunked(5).map { response ->
+                                val guessFields = ArrayList<EmbedBuilder.Field>()
+                                response.forEach {
+                                    val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+
+                                    val field = EmbedBuilder.Field()
+                                    field.name =
+                                        "Guess #" + it.guessId.toString() + ": Guess by " + memberBehavior.asMember().displayName
+                                    field.value = "Guess time is " + it.guessTime
+                                    guessFields.add(field)
+                                }
+
+                                page {
+                                    title = if(arguments.gameid != null) { "List of PKL guesses for game ID #" + arguments.gameid + ": " }
+                                            else { "PKL guess for guess ID #" + arguments.guessid + ":" }
+                                    fields = guessFields
+                                }
+                            }
+
+                            // This will make the pagination function (next prev etc) to disappear after timeout time
+                            timeoutSeconds = 15L
+                        }
+
+                        paginator.send()
+                    }
+                }
+            }
+        }
+    }
+
+    inner class FindGuessArgs : Arguments() {
+        val guessid by optionalInt {
+            name = "guessid"
+            description = "ID of the PKL guess from a certain PKL game"
+        }
+
+        val gameid by optionalInt {
+            name = "gameid"
+            description = "ID of the PKL game"
+        }
+    }
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/GuessGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/GuessGameExtension.kt
@@ -1,0 +1,55 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.int
+import com.kotlindiscord.kord.extensions.commands.converters.impl.string
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respond
+import dev.kord.common.entity.Snowflake
+import uk.co.mutuallyassureddistraction.paketliga.matching.GuessService
+
+class GuessGameExtension(private val guessService: GuessService, private val serverId: Snowflake): Extension() {
+    override val name = "guessExtension"
+
+    override suspend fun setup() {
+        publicSlashCommand(::GuessGameArgs) {
+            name = "guessgame"
+            description = "Guess the delivery time of a game"
+
+            guild(serverId)
+
+            action {
+                val kord = this@GuessGameExtension.kord
+
+                val gameId = arguments.gameid
+                val guessTime = arguments.guesstime
+                val userId = user.asUser().id.value.toString()
+
+                val guessGameResponse = guessService.guessGame(gameId, guessTime, userId)
+
+                val respondMessage = if(!guessGameResponse.success) {
+                    guessGameResponse.failMessage!!
+                } else {
+                    "Guess created by " + user.asUser().mention +
+                            " for game #" + gameId + " with time " + guessGameResponse.guessTime
+                }
+
+                respond {
+                    content = respondMessage
+                }
+            }
+        }
+    }
+
+    inner class GuessGameArgs : Arguments() {
+        val gameid by int {
+            name = "gameid"
+            description = "Game id inputted by user"
+        }
+        val guesstime by string {
+            name = "guesstime"
+            description = "Time guessed by user for the delivery time of the game"
+        }
+    }
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/GuessGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/GuessGameExtension.kt
@@ -7,9 +7,9 @@ import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
 import dev.kord.common.entity.Snowflake
-import uk.co.mutuallyassureddistraction.paketliga.matching.GuessService
+import uk.co.mutuallyassureddistraction.paketliga.matching.GuessUpsertService
 
-class GuessGameExtension(private val guessService: GuessService, private val serverId: Snowflake): Extension() {
+class GuessGameExtension(private val guessUpsertService: GuessUpsertService, private val serverId: Snowflake): Extension() {
     override val name = "guessExtension"
 
     override suspend fun setup() {
@@ -20,13 +20,11 @@ class GuessGameExtension(private val guessService: GuessService, private val ser
             guild(serverId)
 
             action {
-                val kord = this@GuessGameExtension.kord
-
                 val gameId = arguments.gameid
                 val guessTime = arguments.guesstime
                 val userId = user.asUser().id.value.toString()
 
-                val guessGameResponse = guessService.guessGame(gameId, guessTime, userId)
+                val guessGameResponse = guessUpsertService.guessGame(gameId, guessTime, userId)
 
                 val respondMessage = if(!guessGameResponse.success) {
                     guessGameResponse.failMessage!!

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
@@ -1,0 +1,51 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.int
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respond
+import dev.kord.common.entity.Snowflake
+import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
+
+class UpdateGameExtension(private val gameUpsertService: GameUpsertService, private val serverId: Snowflake) : Extension() {
+    override val name = "updateGameExtension"
+    override suspend fun setup() {
+        publicSlashCommand(::UpdateGameArgs) {
+            name = "updategame"
+            description = "Ask the bot to update a game of PKL"
+
+            guild(serverId)
+
+            action {
+                respond {
+                    content = "game updated"
+                }
+            }
+        }
+    }
+
+    inner class UpdateGameArgs : Arguments() {
+        val gameid by int {
+            name = "gameid"
+            description = "Game id inputted by user"
+        }
+
+        val startwindow by optionalString {
+            name = "startwindow"
+            description = "Start window time inputted by user"
+        }
+
+        val closewindow by optionalString {
+            name = "closewindow"
+            description = "Close window time inputted by user"
+        }
+
+        val guessesclose by optionalString {
+            name = "guessesclose"
+            description = "Close window time inputted by user"
+        }
+    }
+
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
@@ -7,7 +7,6 @@ import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.types.respondEphemeral
-import com.kotlindiscord.kord.extensions.types.respondingPaginator
 import dev.kord.common.entity.Snowflake
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 
@@ -37,10 +36,6 @@ class UpdateGameExtension(private val gameUpsertService: GameUpsertService, priv
 
                     respond {
                         content = updateGameResponse[0]
-                    }
-
-                    respondingPaginator {
-
                     }
                 }
             }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
@@ -7,6 +7,7 @@ import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.types.respondEphemeral
+import com.kotlindiscord.kord.extensions.types.respondingPaginator
 import dev.kord.common.entity.Snowflake
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 
@@ -36,6 +37,10 @@ class UpdateGameExtension(private val gameUpsertService: GameUpsertService, priv
 
                     respond {
                         content = updateGameResponse[0]
+                    }
+
+                    respondingPaginator {
+
                     }
                 }
             }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
@@ -6,6 +6,7 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.types.respondEphemeral
 import dev.kord.common.entity.Snowflake
 import uk.co.mutuallyassureddistraction.paketliga.matching.GameUpsertService
 
@@ -19,8 +20,23 @@ class UpdateGameExtension(private val gameUpsertService: GameUpsertService, priv
             guild(serverId)
 
             action {
-                respond {
-                    content = "game updated"
+                val gameId = arguments.gameid
+                val startWindow = arguments.startwindow
+                val closeWindow = arguments.closewindow
+                val guessesClose = arguments.guessesclose
+
+                if(startWindow == null && closeWindow == null && guessesClose == null) {
+                    respondEphemeral {
+                        content = "No time specified, the game will not be updated"
+                    }
+                } else {
+                    val updateGameResponse = gameUpsertService.updateGame(
+                        gameId, startWindow, closeWindow, guessesClose
+                    )
+
+                    respond {
+                        content = updateGameResponse[0]
+                    }
                 }
             }
         }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderService.kt
@@ -1,0 +1,43 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
+import java.time.ZonedDateTime
+
+class GameFinderService(private val gameDao: GameDao) {
+    fun findGames(userId: String?, gameName: String?, gameId: Int?): List<FindGamesResponse> {
+        val gamesResponseList = ArrayList<FindGamesResponse>()
+        if(gameId != null) {
+            val searchedGame: Game? = gameDao.findActiveGameById(gameId)
+            if(searchedGame != null) {
+                gamesResponseList.add(buildResponse(searchedGame))
+            }
+        } else {
+            val searchedGames: List<Game> = gameDao.findActiveGames(gameName, userId)
+            for(searchedGame in searchedGames) {
+                gamesResponseList.add(buildResponse(searchedGame))
+            }
+        }
+
+        return gamesResponseList
+    }
+
+    private fun buildResponse(game: Game): FindGamesResponse {
+        return FindGamesResponse(
+            game.gameId!!,
+            game.userId,
+            game.windowStart,
+            game.windowClose,
+            game.guessesClose
+        )
+    }
+}
+
+class FindGamesResponse(
+    val gameId: Int,
+    val userId: String,
+    val windowStart: ZonedDateTime,
+    val windowClose: ZonedDateTime,
+    val guessesClose: ZonedDateTime
+)
+

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderService.kt
@@ -1,10 +1,17 @@
 package uk.co.mutuallyassureddistraction.paketliga.matching
 
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
-import java.time.ZonedDateTime
+import java.util.*
 
 class GameFinderService(private val gameDao: GameDao) {
+
+    private val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+
     fun findGames(userId: String?, gameName: String?, gameId: Int?): List<FindGamesResponse> {
         val gamesResponseList = ArrayList<FindGamesResponse>()
         if(gameId != null) {
@@ -23,21 +30,30 @@ class GameFinderService(private val gameDao: GameDao) {
     }
 
     private fun buildResponse(game: Game): FindGamesResponse {
+        val startDateString = DateTime(game.windowStart.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(game.windowStart.zone))).toString(dtf)
+        val closeDateString = DateTime(game.windowClose.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(game.windowClose.zone))).toString(dtf)
+        val guessesCloseDateString = DateTime(game.guessesClose.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(game.guessesClose.zone))).toString(dtf)
+
         return FindGamesResponse(
             game.gameId!!,
+            game.gameName,
             game.userId,
-            game.windowStart,
-            game.windowClose,
-            game.guessesClose
+            startDateString,
+            closeDateString,
+            guessesCloseDateString
         )
     }
 }
 
 class FindGamesResponse(
     val gameId: Int,
+    val gameName: String,
     val userId: String,
-    val windowStart: ZonedDateTime,
-    val windowClose: ZonedDateTime,
-    val guessesClose: ZonedDateTime
+    val windowStart: String,
+    val windowClose: String,
+    val guessesClose: String,
 )
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
@@ -4,6 +4,8 @@ import com.zoho.hawking.HawkingTimeParser
 import com.zoho.hawking.datetimeparser.configuration.HawkingConfiguration
 import com.zoho.hawking.language.english.model.DatesFound
 import dev.kord.core.entity.Member
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatter
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
@@ -12,25 +14,28 @@ import java.time.ZoneId
 import java.util.*
 
 class GameUpsertService(private val gameDao: GameDao) {
+
+    private val parser = HawkingTimeParser()
+    private val referenceDate = Date()
+    private val hawkingConfiguration = HawkingConfiguration()
+    private val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+
+    init {
+        hawkingConfiguration.timeZone = ZoneId.systemDefault().toString()
+    }
+
     fun createGame(userGameName: String?, startWindow: String, closeWindow: String, guessesClose: String,
                    userId: String, member: Member?, username: String): String {
         try {
-            val parser = HawkingTimeParser()
-            val referenceDate = Date()
-            val hawkingConfiguration = HawkingConfiguration()
-            hawkingConfiguration.timeZone = ZoneId.systemDefault().toString()
-
-            val startDates: DatesFound = parser.parse(startWindow, referenceDate, hawkingConfiguration, "eng")
-            val closeDates: DatesFound = parser.parse(closeWindow, referenceDate, hawkingConfiguration, "eng")
-            val guessesCloseDates: DatesFound = parser.parse(guessesClose, referenceDate, hawkingConfiguration, "eng")
+            val startDates: DatesFound = parseDate(startWindow)
+            val closeDates: DatesFound = parseDate(closeWindow)
+            val guessesCloseDates: DatesFound = parseDate(guessesClose)
 
             // Start or end doesn't matter if we only have one date at a time
             val startDate = startDates.parserOutputs[0].dateRange.start
             val closeDate = closeDates.parserOutputs[0].dateRange.start
             val guessesCloseDate = guessesCloseDates.parserOutputs[0].dateRange.start
             val gameName = userGameName ?: "Game"
-
-            val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
 
             val gameNameString = gameNameStringMaker(gameName, member, username)
             val startDateString = startDate.toString(dtf)
@@ -56,6 +61,46 @@ class GameUpsertService(private val gameDao: GameDao) {
             // TODO logging
             return "An error has occurred, please re-check your inputs and try again"
         }
+    }
+
+    fun updateGame(gameId: Int, startWindow: String?, closeWindow: String?, guessesClose: String?): Array<String> {
+        try {
+            gameDao.findActiveGameById(gameId)
+                ?: return arrayOf("Wrong Game ID, please check your gameId input and try again")
+
+            val startDates: DatesFound? = startWindow?.let { parseDate(startWindow) }
+            val closeDates: DatesFound? = closeWindow?.let { parseDate(closeWindow) }
+            val guessesCloseDates: DatesFound? = guessesClose?.let { parseDate(guessesClose) }
+
+            val startDate = startDates?.let { startDates.parserOutputs[0].dateRange.start }
+            val closeDate = closeDates?.let { closeDates.parserOutputs[0].dateRange.start }
+            val guessesCloseDate = guessesCloseDates?.let { guessesCloseDates.parserOutputs[0].dateRange.start }
+
+            val updatedGame: Game = gameDao.updateGameTimes(gameId,
+                startDate?.let { startDate.toGregorianCalendar().toZonedDateTime() },
+                closeDate?.let { closeDate.toGregorianCalendar().toZonedDateTime() },
+                guessesCloseDate?.let { guessesCloseDate.toGregorianCalendar().toZonedDateTime() })
+
+            val startDateString = DateTime(updatedGame.windowStart.toInstant().toEpochMilli(),
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(updatedGame.windowStart.zone))).toString(dtf)
+            val closeDateString = DateTime(updatedGame.windowClose.toInstant().toEpochMilli(),
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(updatedGame.windowClose.zone))).toString(dtf)
+            val guessesCloseDateString = DateTime(updatedGame.guessesClose.toInstant().toEpochMilli(),
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(updatedGame.guessesClose.zone))).toString(dtf)
+
+            val gameUpdatedString: String = "Game #" + gameId + " updated: package now arriving between " + startDateString +
+                    " and " + closeDateString + ". Guesses accepted until " + guessesCloseDateString
+            // TODO respond with member mentions by getting the user id from guesses?
+            return arrayOf(gameUpdatedString)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            // TODO logging
+            return arrayOf("An error has occurred, please re-check your inputs and try again")
+        }
+    }
+
+    private fun parseDate(dateString: String): DatesFound {
+        return parser.parse(dateString, referenceDate, hawkingConfiguration, "eng")
     }
 
     private fun gameNameStringMaker(gameName: String?, member: Member?, username: String): String {

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
@@ -59,6 +59,7 @@ class GameUpsertService(private val gameDao: GameDao) {
                     ". Guesses accepted until " + guessesCloseDateString
         } catch (e: Exception) {
             // TODO logging
+            e.printStackTrace()
             return "An error has occurred, please re-check your inputs and try again"
         }
     }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessFinderService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessFinderService.kt
@@ -1,0 +1,49 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
+import uk.co.mutuallyassureddistraction.paketliga.dao.GuessDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Guess
+import java.util.*
+
+class GuessFinderService(private val guessDao: GuessDao) {
+
+    private val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+
+    fun findGuesses(gameId: Int?, guessId: Int?): List<FindGuessesResponse> {
+        val guessResponseList = ArrayList<FindGuessesResponse>()
+        if(gameId == null && guessId == null) {
+            return guessResponseList
+        }
+
+        if(gameId != null) {
+            val searchedGuesses: List<Guess> = guessDao.findGuessesByGameId(gameId)
+            for(searchedGuess in searchedGuesses) {
+                guessResponseList.add(buildResponse(searchedGuess))
+            }
+        } else {
+            val searchedGuess: Guess = guessDao.findGuessByGuessId(guessId!!)
+            guessResponseList.add(buildResponse(searchedGuess))
+        }
+
+        return guessResponseList
+    }
+
+    private fun buildResponse(guess: Guess): FindGuessesResponse {
+        val guessTimeString = DateTime(guess.guessTime.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(guess.guessTime.zone))).toString(dtf)
+
+        return FindGuessesResponse(guess.guessId!!, guess.gameId, guess.userId, guessTimeString)
+    }
+
+    class FindGuessesResponse(
+        val guessId: Int,
+        val gameId: Int,
+        val userId: String,
+        val guessTime: String,
+    )
+}
+
+

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessService.kt
@@ -45,10 +45,10 @@ class GuessService(private val guessDao: GuessDao) {
                             errorString = "Guessing failed, there is already a guess with time $guessTime"
                         }
                         "ERRA0" -> {
-                            errorString = "Guessing failed, there is no active game with gameId $gameId"
+                            errorString = "Guessing failed, there is no active game with game ID #$gameId"
                         }
                         "ERRA1" -> {
-                            errorString = "Guessing failed, guess time is not between start and closing window of game $gameId"
+                            errorString = "Guessing failed, guess time is not between start and closing window of game #$gameId"
                         }
                     }
                 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessService.kt
@@ -1,0 +1,75 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import com.zoho.hawking.HawkingTimeParser
+import com.zoho.hawking.datetimeparser.configuration.HawkingConfiguration
+import com.zoho.hawking.language.english.model.DatesFound
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
+import uk.co.mutuallyassureddistraction.paketliga.dao.GuessDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Guess
+import java.sql.SQLException
+import java.util.*
+
+class GuessService(private val guessDao: GuessDao) {
+
+    private val parser = HawkingTimeParser()
+    private val referenceDate = Date()
+    private val hawkingConfiguration = HawkingConfiguration()
+    private val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+
+    fun guessGame(gameId: Int, guessTime: String, userId: String): GuessGameResponse {
+        val guessDates: DatesFound = parseDate(guessTime)
+        val guessDate = guessDates.parserOutputs[0].dateRange.start
+        val guessDateString = guessDate.toString(dtf)
+
+        try {
+            guessDao.createGuess(
+                Guess(
+                    guessId = null,
+                    gameId = gameId,
+                    guessTime = guessDate.toGregorianCalendar().toZonedDateTime(),
+                    userId = userId
+                )
+            )
+
+            return GuessGameResponse(true, null, gameId, userId, guessDateString)
+        } catch (e: Exception) {
+            var errorString = "An error has occurred, please re-check your inputs and try again"
+            // TODO logging
+            when(e) {
+                is UnableToExecuteStatementException -> {
+                    val original = e.cause as SQLException
+                    when (original.sqlState) {
+                        "23505" -> {
+                            errorString = "Guessing failed, there is already a guess with time $guessTime"
+                        }
+                        "ERRA0" -> {
+                            errorString = "Guessing failed, there is no active game with gameId $gameId"
+                        }
+                        "ERRA1" -> {
+                            errorString = "Guessing failed, guess time is not between start and closing window of game $gameId"
+                        }
+                    }
+                }
+                else -> {
+                    e.printStackTrace()
+                }
+            }
+
+            return GuessGameResponse(false, errorString, gameId, userId, guessTime)
+        }
+    }
+
+    class GuessGameResponse(
+        val success: Boolean,
+        val failMessage: String?,
+        val gameId: Int,
+        val userId: String,
+        val guessTime: String,
+    )
+
+    private fun parseDate(dateString: String): DatesFound {
+        return parser.parse(dateString, referenceDate, hawkingConfiguration, "eng")
+    }
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessUpsertService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessUpsertService.kt
@@ -11,7 +11,7 @@ import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Guess
 import java.sql.SQLException
 import java.util.*
 
-class GuessService(private val guessDao: GuessDao) {
+class GuessUpsertService(private val guessDao: GuessDao) {
 
     private val parser = HawkingTimeParser()
     private val referenceDate = Date()

--- a/src/main/resources/GameTrigger.sql
+++ b/src/main/resources/GameTrigger.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION check_game_active_and_userid()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NOT (NEW.deliverytime BETWEEN (SELECT windowstart FROM game WHERE gameid = NEW.gameid) AND (SELECT windowclose FROM game WHERE gameid = NEW.gameid)) THEN
+        RAISE EXCEPTION 'Delivery time % is not between start and closing window range of the game', NEW.deliverytime USING ERRCODE = 'ERRG0';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER check_game_active_and_userid_trigger
+BEFORE UPDATE ON GAME
+FOR EACH ROW
+EXECUTE FUNCTION check_game_active_and_userid();

--- a/src/main/resources/GuessTrigger.sql
+++ b/src/main/resources/GuessTrigger.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION check_gameid_and_guesstime()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM game WHERE gameid = NEW.gameid) THEN
+        RAISE EXCEPTION 'Game ID % does not exist.', NEW.gameid USING ERRCODE = 'ERRA0';
+    END IF;
+    IF NOT (NEW.guesstime BETWEEN (SELECT windowstart FROM game WHERE gameid = NEW.gameid) AND (SELECT windowclose FROM game WHERE gameid = NEW.gameid)) THEN
+        RAISE EXCEPTION 'Guess time % is not between start and closing window range of the game', NEW.guesstime USING ERRCODE = 'ERRA1';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER check_gameid_and_guesstime_trigger
+BEFORE INSERT ON GUESS
+FOR EACH ROW
+EXECUTE FUNCTION check_gameid_and_guesstime();

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
@@ -35,15 +35,6 @@ fun setUpDatabaseTables(jdbi: Jdbi) {
     jdbi.withHandle<IntArray, Exception> {
         val batch: Batch = it.createBatch()
         batch.add("""
-            CREATE TABLE GUESS (
-               guessId SERIAL PRIMARY KEY,
-               gameId INT not null,
-               userId VARCHAR(50) not null,
-               guessTime TIMESTAMPTZ not null,
-               CONSTRAINT game_and_guess_time UNIQUE (gameId, guessTime)
-            )
-        """.trimIndent())
-        batch.add("""
             CREATE TABLE GAME (
                 gameId SERIAL PRIMARY KEY,
                 gameName VARCHAR(50) not null,
@@ -53,6 +44,19 @@ fun setUpDatabaseTables(jdbi: Jdbi) {
                 deliveryTime TIMESTAMPTZ null,
                 userId VARCHAR(50) not null,
                 gameActive BOOLEAN not null
+            )
+        """.trimIndent())
+        batch.add("""
+            CREATE TABLE GUESS (
+                guessId SERIAL PRIMARY KEY,
+                gameId INT not null,
+                userId VARCHAR(50) not null,
+                guessTime TIMESTAMPTZ not null,
+                CONSTRAINT fk_gameid
+                    FOREIGN KEY (gameId) 
+                        REFERENCES GAME(gameId)
+                        ON DELETE CASCADE,
+                CONSTRAINT game_and_guess_time UNIQUE (gameId, guessTime)
             )
         """.trimIndent())
         batch.execute()

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
@@ -96,6 +96,33 @@ fun setUpDatabaseTables(jdbi: Jdbi) {
             FOR EACH ROW
             EXECUTE FUNCTION check_gameid_and_guesstime();
         """.trimIndent())
+        batch.add("""
+            CREATE TABLE WIN (
+                winId SERIAL PRIMARY KEY,
+                gameId INT not null UNIQUE,
+                guessId INT not null,
+                date TIMESTAMPTZ not null,
+                CONSTRAINT fk_gameid
+                    FOREIGN KEY (gameId) 
+                        REFERENCES GAME(gameId)
+                        ON DELETE CASCADE,
+                CONSTRAINT fk_guessid
+                    FOREIGN KEY (guessId)
+                        REFERENCES GUESS(guessId)
+                        ON DELETE CASCADE
+            )
+        """.trimIndent())
+        batch.add("""
+            CREATE TABLE POINT (
+                pointId SERIAL PRIMARY KEY,
+                userId VARCHAR(50) not null,
+                played INT not null,
+                won INT not null,
+                lost INT not null,
+                totalPoint INT not null,
+                CONSTRAINT unique_user_id UNIQUE (userId)
+            )
+        """.trimIndent())
         batch.execute()
     }
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
@@ -59,6 +59,26 @@ fun setUpDatabaseTables(jdbi: Jdbi) {
                 CONSTRAINT game_and_guess_time UNIQUE (gameId, guessTime)
             )
         """.trimIndent())
+        batch.add("""
+            CREATE OR REPLACE FUNCTION check_gameid_and_guesstime()
+            RETURNS TRIGGER AS ${'$'}${'$'}
+            BEGIN
+                IF NOT EXISTS (SELECT 1 FROM game WHERE gameid = NEW.gameid) THEN
+                    RAISE EXCEPTION 'Game ID % does not exist.', NEW.gameid USING ERRCODE = 'ERRA0';
+                END IF;
+                IF NOT (NEW.guesstime BETWEEN (SELECT windowstart FROM game WHERE gameid = NEW.gameid) AND (SELECT windowclose FROM game WHERE gameid = NEW.gameid)) THEN
+                    RAISE EXCEPTION'Guess time % is not between start and closing window range of the game', NEW.guesstime USING ERRCODE = 'ERRA1';
+                END IF;
+                RETURN NEW;
+            END;
+            ${'$'}${'$'} LANGUAGE plpgsql;
+        """.trimIndent())
+        batch.add("""
+            CREATE TRIGGER check_gameid_and_guesstime_trigger
+            BEFORE INSERT ON GUESS
+            FOR EACH ROW
+            EXECUTE FUNCTION check_gameid_and_guesstime();
+        """.trimIndent())
         batch.execute()
     }
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
@@ -36,20 +36,21 @@ fun setUpDatabaseTables(jdbi: Jdbi) {
         val batch: Batch = it.createBatch()
         batch.add("""
             CREATE TABLE GUESS (
-               guessId uuid not null,
-               gameId uuid not null,
+               guessId SERIAL PRIMARY KEY,
+               gameId INT not null,
                userId VARCHAR(50) not null,
-               guessTime VARCHAR(50) not null
+               guessTime TIMESTAMPTZ not null,
+               CONSTRAINT game_and_guess_time UNIQUE (gameId, guessTime)
             )
         """.trimIndent())
         batch.add("""
             CREATE TABLE GAME (
                 gameId SERIAL PRIMARY KEY,
                 gameName VARCHAR(50) not null,
-                windowStart VARCHAR(50) not null,
-                windowClose VARCHAR(50) not null,
-                guessesClose VARCHAR(50) not null,
-                deliveryTime VARCHAR(50) null,
+                windowStart TIMESTAMPTZ not null,
+                windowClose TIMESTAMPTZ not null,
+                guessesClose TIMESTAMPTZ not null,
+                deliveryTime TIMESTAMPTZ null,
                 userId VARCHAR(50) not null,
                 gameActive BOOLEAN not null
             )

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
@@ -64,6 +64,27 @@ class GameDaoTest {
         assertEquals(createdGame.windowStart, updatedGame.windowStart)
     }
 
+    @DisplayName("findActiveGamesByUserId() will return list of games by user id")
+    @Test
+    fun canSuccessfullyFindActiveGamesByUserId() {
+        val expected = Game(
+            gameId = 2,
+            gameName = "A second game",
+            windowStart = ZonedDateTime.parse("2023-04-10T10:00:00.000Z[Europe/London]"),
+            windowClose = ZonedDateTime.parse("2023-04-10T18:00:00.000Z[Europe/London]"),
+            guessesClose = ZonedDateTime.parse("2023-04-10T08:00:00.000Z[Europe/London]"),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
+        target.createGame(expected)
+
+        val games: List<Game> = target.findActiveGamesByUserId("Z")
+
+        assertEquals(games[0], createdGame)
+        assertEquals(games[1], expected)
+    }
+
     @DisplayName("finishGame() will successfully update the game deliveryTime and gameActive to false")
     @Test
     fun canSuccessfullyFinishGame() {

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
@@ -36,13 +36,6 @@ class GameDaoTest {
         assertEquals(result, createdGame)
     }
 
-    @DisplayName("findActiveGameByName() will successfully return a game by name")
-    @Test
-    fun canSuccessfullyFindActiveGameByName() {
-        val searchedGame: Game = target.findActiveGameByName("random")
-        assertEquals(createdGame, searchedGame)
-    }
-
     @DisplayName("findActiveGameById() will successfully return a game by id")
     @Test
     fun canSuccessfullyFindActiveGameById() {
@@ -70,7 +63,47 @@ class GameDaoTest {
         assertEquals(createdGame.windowStart, updatedGame.windowStart)
     }
 
-    @DisplayName("findActiveGamesByUserId() will return list of games by user id")
+    @DisplayName("finishGame() will successfully update the game deliveryTime and gameActive to false")
+    @Test
+    fun canSuccessfullyFinishGame() {
+        val secondCreatedGame = Game(
+            gameId = 2,
+            gameName = "A second game",
+            windowStart = ZonedDateTime.parse("2023-04-10T10:00:00.000Z[Europe/London]"),
+            windowClose = ZonedDateTime.parse("2023-04-10T18:00:00.000Z[Europe/London]"),
+            guessesClose = ZonedDateTime.parse("2023-04-10T08:00:00.000Z[Europe/London]"),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
+        target.createGame(secondCreatedGame)
+
+        val games: List<Game> = target.findActiveGames(null, null)
+
+        assertEquals(createdGame, games[0])
+        assertEquals(secondCreatedGame, games[1])
+    }
+
+
+    @DisplayName("findActiveGames() with name will successfully return a game by name")
+    @Test
+    fun canSuccessfullyFindActiveGameByName() {
+        val searchedGame: List<Game> = target.findActiveGames("random", null)
+        assertEquals(createdGame, searchedGame[0])
+    }
+
+    @DisplayName("findActiveGame() with null params will successfully get all active games")
+    @Test
+    fun canSuccessfullyFindActiveGames() {
+        val finishedGame: Game = target.finishGame(1,
+            ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
+
+        assertEquals(finishedGame.deliveryTime, ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
+        assertEquals(finishedGame.gameActive, false)
+    }
+
+
+    @DisplayName("findActiveGames() with userId param will return list of games by user id")
     @Test
     fun canSuccessfullyFindActiveGamesByUserId() {
         val expected = Game(
@@ -85,20 +118,10 @@ class GameDaoTest {
         )
         target.createGame(expected)
 
-        val games: List<Game> = target.findActiveGamesByUserId("Z")
+        val games: List<Game> = target.findActiveGames(null, "Z")
 
         assertEquals(games[0], createdGame)
         assertEquals(games[1], expected)
-    }
-
-    @DisplayName("finishGame() will successfully update the game deliveryTime and gameActive to false")
-    @Test
-    fun canSuccessfullyFinishGame() {
-        val finishedGame: Game = target.finishGame(1,
-            ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
-
-        assertEquals(finishedGame.deliveryTime, ZonedDateTime.parse("2023-04-07T16:37:00.000Z[Europe/London]"))
-        assertEquals(finishedGame.gameActive, false)
     }
 
     private fun createGame(): Game {

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDaoTest.kt
@@ -8,6 +8,7 @@ import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
 import java.time.ZonedDateTime
 import java.util.*
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class GameDaoTest {
     private lateinit var target: GameDao
@@ -45,17 +46,22 @@ class GameDaoTest {
     @DisplayName("findActiveGameById() will successfully return a game by id")
     @Test
     fun canSuccessfullyFindActiveGameById() {
-        val searchedGame: Game = target.findActiveGameById(1)
+        val searchedGame: Game? = target.findActiveGameById(1)
         assertEquals(createdGame, searchedGame)
+    }
+
+    @DisplayName("findActiveGameById() will return null on unknown gameId")
+    @Test
+    fun getNullOnWrongGameIdInFindActiveGameById() {
+        val searchedGame: Game? = target.findActiveGameById(999)
+        assertNull(searchedGame)
     }
 
     @DisplayName("updateGameTimes() will successfully update the game time if not null")
     @Test
     fun canSuccessfullyUpdateGameTimes() {
-        target.updateGameTimes(1, null, null,
+        val updatedGame: Game = target.updateGameTimes(1, null, null,
             ZonedDateTime.parse("2023-04-07T13:00:00.000Z[Europe/London]"))
-
-        val updatedGame: Game = target.findActiveGameById(1)
         // Guesses close should be updated..
         assertEquals(updatedGame.guessesClose, ZonedDateTime.parse("2023-04-07T13:00:00.000Z[Europe/London]"))
 

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDaoTest.kt
@@ -12,6 +12,7 @@ import java.time.ZonedDateTime
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class GuessDaoTest {
     lateinit var gameDao: GameDao
@@ -147,5 +148,35 @@ class GuessDaoTest {
             assertIs<PSQLException>(original)
             assertEquals("ERRA1", original.sqlState)
         }
+    }
+
+    @DisplayName("findGuessesByGameId() will return a list of guesses")
+    @Test
+    fun canSuccessfullyFindGuessesGivenGameId() {
+        val expected = Guess(
+            guessId = 1,
+            gameId = 1,
+            userId = "PostMasterGeneral",
+            guessTime = ZonedDateTime.parse("2023-04-07T16:00:00.000Z[Europe/London]")
+        )
+        target.createGuess(expected)
+
+        val result = target.findGuessesByGameId(1)
+        assertEquals(result, listOf(expected))
+    }
+
+    @DisplayName("findGuessesByGameId() will return empty list on wrong game Id")
+    @Test
+    fun canSuccessfullyReturnEmptyListGivenWrongGameId() {
+        val expected = Guess(
+            guessId = 1,
+            gameId = 1,
+            userId = "PostMasterGeneral",
+            guessTime = ZonedDateTime.parse("2023-04-07T16:00:00.000Z[Europe/London]")
+        )
+        target.createGuess(expected)
+
+        val result = target.findGuessesByGameId(999)
+        assertTrue { result.isEmpty() }
     }
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDaoTest.kt
@@ -50,7 +50,7 @@ class GuessDaoTest {
             guessId = 1,
             gameId = 1,
             userId = "PostMasterGeneral",
-            guessTime = ZonedDateTime.parse("2023-03-01T22:51:20.123330Z[Europe/London]")
+            guessTime = ZonedDateTime.parse("2023-04-07T16:00:00.000Z[Europe/London]")
         )
         target.createGuess(expected)
 
@@ -73,7 +73,7 @@ class GuessDaoTest {
             guessId = 1,
             gameId = 1,
             userId = "PostMasterGeneral",
-            guessTime = ZonedDateTime.parse("2023-03-01T22:51:20.123330Z[Europe/London]")
+            guessTime = ZonedDateTime.parse("2023-04-07T16:00:00.000Z[Europe/London]")
         )
         target.createGuess(expected)
 
@@ -83,12 +83,12 @@ class GuessDaoTest {
 
     @DisplayName("createGuess() will fail to insert when no gameId found in the Game table")
     @Test
-    fun failToInsertOnGameIdForeignKeyConstraintViolation() {
+    fun failToInsertOnGameIdForeignKeyTriggerViolation() {
         val expectedOne = Guess(
             guessId = 1,
             gameId = 999,
             userId = "PostMasterGeneral",
-            guessTime = ZonedDateTime.parse("2023-03-01T22:51:20.123330Z[Europe/London]")
+            guessTime = ZonedDateTime.parse("2023-04-07T16:00:00.000Z[Europe/London]")
         )
 
         // SQLSTATE 23503: The insert or update value of a foreign key is invalid
@@ -97,7 +97,7 @@ class GuessDaoTest {
         } catch(e: UnableToExecuteStatementException) {
             val original = e.cause
             assertIs<PSQLException>(original)
-            assertEquals("23503", original.sqlState)
+            assertEquals("ERRA0", original.sqlState)
         }
     }
 
@@ -108,15 +108,15 @@ class GuessDaoTest {
             guessId = 1,
             gameId = 1,
             userId = "PostMasterGeneral",
-            guessTime = ZonedDateTime.parse("2023-03-01T22:51:20.123330Z[Europe/London]")
+            guessTime = ZonedDateTime.parse("2023-04-07T16:00:00.000Z[Europe/London]")
         )
         target.createGuess(expectedOne)
 
         val expectedTwo = Guess(
             guessId = 2,
             gameId = 1,
-            userId = "PostMasterGeneral",
-            guessTime = ZonedDateTime.parse("2023-03-01T22:51:20.123330Z[Europe/London]")
+            userId = "Z",
+            guessTime = ZonedDateTime.parse("2023-04-07T16:00:00.000Z[Europe/London]")
         )
 
         // SQLSTATE 23505:
@@ -127,6 +127,25 @@ class GuessDaoTest {
             val original = e.cause
             assertIs<PSQLException>(original)
             assertEquals("23505", original.sqlState)
+        }
+    }
+
+    @DisplayName("createGuess() will fail to insert when the guessTime is not between guess window range")
+    @Test
+    fun failToInsertOnGuessOutOfWindowRangeTriggerViolation() {
+        val expectedOne = Guess(
+            guessId = 1,
+            gameId = 1,
+            userId = "PostMasterGeneral",
+            guessTime = ZonedDateTime.parse("2023-04-07T20:00:00.000Z[Europe/London]")
+        )
+
+        try {
+            target.createGuess(expectedOne)
+        } catch(e: UnableToExecuteStatementException) {
+            val original = e.cause
+            assertIs<PSQLException>(original)
+            assertEquals("ERRA1", original.sqlState)
         }
     }
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDaoTest.kt
@@ -1,0 +1,99 @@
+package uk.co.mutuallyassureddistraction.paketliga.dao
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Point
+import kotlin.test.assertEquals
+
+class PointDaoTest {
+    private lateinit var target: PointDao
+    private lateinit var testWrapper: DaoTestWrapper
+
+    @BeforeEach
+    fun setUp() {
+        testWrapper = initTests()
+        target = testWrapper.buildDao(PointDao::class.java)
+    }
+
+    @DisplayName("addWin() without prior insert will successfully insert a point into the table")
+    @Test
+    fun canSuccessfullyInsertWinIntoTable() {
+        target.addWin(createdPoint())
+        val result = testWrapper.executeSimpleQuery<Point>(
+            """SELECT * FROM POINT""".trimIndent()
+        )
+        assertEquals(result, createdPoint())
+    }
+
+    @DisplayName("addWin() with prior insert will successfully update the point and won in the table")
+    @Test
+    fun canSuccessfullyUpdateWinOnConflictIntoTable() {
+        val expected = createdPoint()
+        target.addWin(expected)
+        val firstResult = testWrapper.executeSimpleQuery<Point>(
+            """SELECT * FROM POINT""".trimIndent()
+        )
+        assertEquals(firstResult.userId, expected.userId)
+        assertEquals(firstResult.totalPoint, 1)
+        assertEquals(firstResult.won, 1)
+
+        target.addWin(expected)
+        val secondResult = testWrapper.executeSimpleQuery<Point>(
+            """SELECT * FROM POINT""".trimIndent()
+        )
+        assertEquals(secondResult.userId, expected.userId)
+        assertEquals(secondResult.totalPoint, 2)
+        assertEquals(secondResult.won, 2)
+    }
+
+    @DisplayName("addLost() without prior insert will successfully insert a point into the table")
+    @Test
+    fun canSuccessfullyInsertLostIntoTable() {
+        target.addLost(createdPoint())
+        val result = testWrapper.executeSimpleQuery<Point>(
+            """SELECT * FROM POINT""".trimIndent()
+        )
+        assertEquals(result, createdPoint())
+    }
+
+    @DisplayName("addLost() with prior insert will successfully update the point and lost in the table")
+    @Test
+    fun canSuccessfullyUpdateLostOnConflictIntoTable() {
+        val expected = createdPoint()
+        target.addLost(expected)
+        val firstResult = testWrapper.executeSimpleQuery<Point>(
+            """SELECT * FROM POINT""".trimIndent()
+        )
+        assertEquals(firstResult.userId, expected.userId)
+        assertEquals(firstResult.totalPoint, 1)
+        assertEquals(firstResult.lost, 1)
+
+        target.addLost(expected)
+        val secondResult = testWrapper.executeSimpleQuery<Point>(
+            """SELECT * FROM POINT""".trimIndent()
+        )
+        assertEquals(secondResult.userId, expected.userId)
+        assertEquals(secondResult.totalPoint, 0)
+        assertEquals(secondResult.lost, 2)
+
+        target.addLost(expected)
+        val thirdResult = testWrapper.executeSimpleQuery<Point>(
+            """SELECT * FROM POINT""".trimIndent()
+        )
+        assertEquals(thirdResult.userId, expected.userId)
+        assertEquals(thirdResult.totalPoint, 0)
+        assertEquals(thirdResult.lost, 3)
+    }
+
+    private fun createdPoint(): Point {
+        return Point(
+            pointId = 1,
+            userId = "Z",
+            played = 1,
+            won = 1,
+            lost = 1,
+            totalPoint = 1,
+        )
+    }
+}

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/WinDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/WinDaoTest.kt
@@ -1,0 +1,75 @@
+package uk.co.mutuallyassureddistraction.paketliga.dao
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Guess
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Win
+import java.time.ZonedDateTime
+import kotlin.test.assertEquals
+
+class WinDaoTest {
+    private lateinit var gameDao: GameDao
+    private lateinit var guessDao: GuessDao
+    private lateinit var target: WinDao
+    private lateinit var testWrapper: DaoTestWrapper
+
+    @BeforeEach
+    fun setUp() {
+        testWrapper = initTests()
+        gameDao = testWrapper.buildDao(GameDao::class.java)
+        gameDao.createGame(
+            Game(
+                gameId = 1,
+                gameName = "random game name",
+                windowStart = ZonedDateTime.parse("2023-04-07T09:00:00.000Z[Europe/London]"),
+                windowClose = ZonedDateTime.parse("2023-04-07T17:00:00.000Z[Europe/London]"),
+                guessesClose = ZonedDateTime.parse("2023-04-07T12:00:00.000Z[Europe/London]"),
+                deliveryTime = null,
+                userId = "Z",
+                gameActive = true
+            )
+        )
+        guessDao = testWrapper.buildDao(GuessDao::class.java)
+        guessDao.createGuess(
+            Guess(
+                guessId = 1,
+                gameId = 1,
+                userId = "PostMasterGeneral",
+                guessTime = ZonedDateTime.parse("2023-04-07T16:00:00.000Z[Europe/London]")
+            )
+        )
+
+        target = testWrapper.buildDao(WinDao::class.java)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        testWrapper.stopContainers()
+    }
+
+    @DisplayName("createGuess() will successfully insert guess into table")
+    @Test
+    fun canSuccessfullyInsertIntoTable() {
+        val expected = createWin()
+        target.addWinningGuess(expected)
+
+        val result = testWrapper.executeSimpleQuery<Win>(
+            """SELECT * FROM WIN""".trimIndent()
+        )
+        assertEquals(expected, result)
+    }
+
+    private fun createWin(): Win {
+        val expected = Win(
+            winId = 1,
+            gameId = 1,
+            guessId = 1,
+            date = ZonedDateTime.parse("2023-04-07T12:00:00.000Z[Europe/London]")
+        )
+
+        return expected
+    }
+}

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderServiceTest.kt
@@ -1,0 +1,59 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
+import java.time.ZonedDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GameFinderServiceTest {
+    private lateinit var target: GameFinderService
+    private val expectedGame: Game = getGameStub()
+
+    @BeforeEach
+    fun setUp() {
+        val gameDao = mockk<GameDao>()
+        every {gameDao.findActiveGameById(any())} returns expectedGame
+        every {gameDao.findActiveGames(any(), any()) } returns listOf(expectedGame)
+        target = GameFinderService(gameDao)
+    }
+
+    @DisplayName("findGames() with gameId param will return a game after searched using gameId")
+    @Test
+    fun returnListOfResponseWhenSearchingWithGameId() {
+        val returnedList = target.findGames(null, null, 1)
+        assertEquals(returnedList[0].gameId, expectedGame.gameId)
+        assertEquals(returnedList[0].userId, expectedGame.userId)
+        assertEquals(returnedList[0].windowStart, expectedGame.windowStart)
+        assertEquals(returnedList[0].windowClose, expectedGame.windowClose)
+        assertEquals(returnedList[0].guessesClose, expectedGame.guessesClose)
+    }
+
+    @DisplayName("findGames() with gameName / userId param will return searched game")
+    @Test
+    fun returnListOfResponseWhenSearchingWithGameNameAndOrUserId() {
+        val returnedList = target.findGames("Z", "testing", null)
+        assertEquals(returnedList[0].gameId, expectedGame.gameId)
+        assertEquals(returnedList[0].userId, expectedGame.userId)
+        assertEquals(returnedList[0].windowStart, expectedGame.windowStart)
+        assertEquals(returnedList[0].windowClose, expectedGame.windowClose)
+        assertEquals(returnedList[0].guessesClose, expectedGame.guessesClose)
+    }
+
+    private fun getGameStub(): Game {
+        return Game(
+            gameId = 1,
+            gameName = "Testing testing",
+            windowStart = ZonedDateTime.now().withHour(15).withMinute(0),
+            windowClose = ZonedDateTime.now().withHour(19).withMinute(0),
+            guessesClose = ZonedDateTime.now().withHour(14).withMinute(0),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
+    }
+}

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameFinderServiceTest.kt
@@ -2,17 +2,23 @@ package uk.co.mutuallyassureddistraction.paketliga.matching
 
 import io.mockk.every
 import io.mockk.mockk
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
 import java.time.ZonedDateTime
+import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class GameFinderServiceTest {
     private lateinit var target: GameFinderService
     private val expectedGame: Game = getGameStub()
+    private val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
 
     @BeforeEach
     fun setUp() {
@@ -28,9 +34,9 @@ class GameFinderServiceTest {
         val returnedList = target.findGames(null, null, 1)
         assertEquals(returnedList[0].gameId, expectedGame.gameId)
         assertEquals(returnedList[0].userId, expectedGame.userId)
-        assertEquals(returnedList[0].windowStart, expectedGame.windowStart)
-        assertEquals(returnedList[0].windowClose, expectedGame.windowClose)
-        assertEquals(returnedList[0].guessesClose, expectedGame.guessesClose)
+        assertEquals(returnedList[0].windowStart, zonedDateTimeToString(expectedGame.windowStart))
+        assertEquals(returnedList[0].windowClose, zonedDateTimeToString(expectedGame.windowClose))
+        assertEquals(returnedList[0].guessesClose, zonedDateTimeToString(expectedGame.guessesClose))
     }
 
     @DisplayName("findGames() with gameName / userId param will return searched game")
@@ -39,9 +45,14 @@ class GameFinderServiceTest {
         val returnedList = target.findGames("Z", "testing", null)
         assertEquals(returnedList[0].gameId, expectedGame.gameId)
         assertEquals(returnedList[0].userId, expectedGame.userId)
-        assertEquals(returnedList[0].windowStart, expectedGame.windowStart)
-        assertEquals(returnedList[0].windowClose, expectedGame.windowClose)
-        assertEquals(returnedList[0].guessesClose, expectedGame.guessesClose)
+        assertEquals(returnedList[0].windowStart, zonedDateTimeToString(expectedGame.windowStart))
+        assertEquals(returnedList[0].windowClose, zonedDateTimeToString(expectedGame.windowClose))
+        assertEquals(returnedList[0].guessesClose,zonedDateTimeToString(expectedGame.guessesClose))
+    }
+
+    private fun zonedDateTimeToString(dtz : ZonedDateTime): String {
+        return DateTime(dtz.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(dtz.zone))).toString(dtf)
     }
 
     private fun getGameStub(): Game {

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameResultResolverTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameResultResolverTest.kt
@@ -76,8 +76,8 @@ class GameResultResolverTest {
 
     private fun buildGuess(guessTime: String): Guess {
         return Guess(
-            guessId = UUID.randomUUID(),
-            gameId = UUID.randomUUID(),
+            guessId = 1,
+            gameId = 1,
             userId = "PostMasterGeneral",
             guessTime = ZonedDateTime.parse(guessTime)
         )

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
@@ -9,18 +9,25 @@ import org.joda.time.format.DateTimeFormatter
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
+import java.time.ZonedDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class GameUpsertServiceTest {
 
     private lateinit var target: GameUpsertService
+    private lateinit var dtf: DateTimeFormatter
 
     @BeforeEach
     fun setUp() {
         val gameDao = mockk<GameDao>()
         every {gameDao.createGame(any())} returns Unit
+        every {gameDao.findActiveGameById(999)} returns null
+        every {gameDao.findActiveGameById(1)} returns mockk<Game>()
+        every {gameDao.updateGameTimes(any(), any(), any(), any())} returns getUpdatedGameStub()
         target = GameUpsertService(gameDao)
+        dtf = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
     }
 
     @DisplayName("createGame() will return string with gameName and member mentioned if both values are not null")
@@ -31,7 +38,7 @@ class GameUpsertServiceTest {
         val gameName = "Random Amazon package"
         val returnedString = target.createGame(gameName, "today 2pm",
             "today 7pm", "today 1pm", "1234", member, "ZLX")
-        val expectedString = getExpectedString(gameName, member, "ZLX")
+        val expectedString = getCreateGameExpectedString(gameName, member, "ZLX")
         assertEquals(expectedString, returnedString)
     }
 
@@ -40,13 +47,49 @@ class GameUpsertServiceTest {
     fun returnStringWithNullGameNameAndMember() {
         val returnedString = target.createGame(null, "today 2pm",
             "today 7pm", "today 1pm", "1234", null, "ZLX")
-        val expectedString = getExpectedString(null, null, "ZLX")
+        val expectedString = getCreateGameExpectedString(null, null, "ZLX")
         assertEquals(returnedString, expectedString)
     }
 
-    private fun getExpectedString(userGameName: String?, member: Member?, username: String): String {
-        val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+    @DisplayName("updateGame() will return wrong Game ID string")
+    @Test
+    fun returnStringWithWrongGameIDInformation() {
+        target.createGame(null, "today 2pm",
+            "today 7pm", "today 1pm", "1234", null, "ZLX")
+        val returnedString = target.updateGame(999, null, null, null)
+        val expectedString = "Wrong Game ID, please check your gameId input and try again"
+        assertEquals(returnedString[0], expectedString)
+    }
 
+    @DisplayName("updateGame() will return updated game string")
+    @Test
+    fun returnStringWithUpdatedGameInfo() {
+        target.createGame(null, "today 2pm",
+            "today 7pm", "today 1pm", "1234", null, "ZLX")
+        val returnedString = target.updateGame(1, "today 3 pm", null, "today 2 pm")
+
+        val startTime = LocalDateTime.now().withHourOfDay(15).withMinuteOfHour(0).toString(dtf)
+        val closeTime = LocalDateTime.now().withHourOfDay(19).withMinuteOfHour(0).toString(dtf)
+        val guessesCloseTime = LocalDateTime.now().withHourOfDay(14).withMinuteOfHour(0).toString(dtf)
+        val expectedString = "Game #1 updated: package now arriving between " + startTime +
+                " and " + closeTime + ". Guesses accepted until " + guessesCloseTime
+        assertEquals(returnedString[0], expectedString)
+    }
+
+    private fun getUpdatedGameStub(): Game {
+        return Game(
+            gameId = 1,
+            gameName = "Testing testing",
+            windowStart = ZonedDateTime.now().withHour(15).withMinute(0),
+            windowClose = ZonedDateTime.now().withHour(19).withMinute(0),
+            guessesClose = ZonedDateTime.now().withHour(14).withMinute(0),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
+    }
+
+    private fun getCreateGameExpectedString(userGameName: String?, member: Member?, username: String): String {
         val startTime = LocalDateTime.now().withHourOfDay(14).withMinuteOfHour(0).toString(dtf)
         val closeTime = LocalDateTime.now().withHourOfDay(19).withMinuteOfHour(0).toString(dtf)
         val guessesCloseTime = LocalDateTime.now().withHourOfDay(13).withMinuteOfHour(0).toString(dtf)

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessFinderServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessFinderServiceTest.kt
@@ -1,0 +1,62 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import io.mockk.every
+import io.mockk.mockk
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import uk.co.mutuallyassureddistraction.paketliga.dao.GuessDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Guess
+import java.time.ZonedDateTime
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GuessFinderServiceTest {
+    private lateinit var target: GuessFinderService
+    private val expectedGuess: Guess = getGuessStub()
+    private val dtf: DateTimeFormatter = DateTimeFormat.forPattern("dd-MMM-yy HH:mm")
+
+    @BeforeEach
+    fun setUp() {
+        val guessDao = mockk<GuessDao>()
+        every {guessDao.findGuessByGuessId(any())} returns expectedGuess
+        every {guessDao.findGuessesByGameId(any())} returns listOf(expectedGuess)
+        target = GuessFinderService(guessDao)
+    }
+
+    @DisplayName("findGuesses() with gameId param will return list of guesses after searched using gameId")
+    @Test
+    fun returnListOfResponseWhenSearchingWithGameId() {
+        val returnedList = target.findGuesses(1, null)
+        assertEquals(returnedList[0].gameId, expectedGuess.gameId)
+        assertEquals(returnedList[0].userId, expectedGuess.userId)
+        assertEquals(returnedList[0].guessTime, zonedDateTimeToString(expectedGuess.guessTime))
+    }
+
+    @DisplayName("findGuesses() with guessId param will return searched guess")
+    @Test
+    fun returnListOfResponseWhenSearchingWithGuessId() {
+        val returnedList = target.findGuesses(null, 1)
+        assertEquals(returnedList[0].gameId, expectedGuess.gameId)
+        assertEquals(returnedList[0].userId, expectedGuess.userId)
+        assertEquals(returnedList[0].guessTime, zonedDateTimeToString(expectedGuess.guessTime))
+    }
+
+    private fun zonedDateTimeToString(zdt : ZonedDateTime): String {
+        return DateTime(zdt.toInstant().toEpochMilli(),
+            DateTimeZone.forTimeZone(TimeZone.getTimeZone(zdt.zone))).toString(dtf)
+    }
+
+    private fun getGuessStub(): Guess {
+        return Guess (
+            guessId = 1,
+            gameId = 1,
+            userId = "Z",
+            guessTime = ZonedDateTime.now().withHour(14).withMinute(38)
+        )
+    }
+}

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessServiceTest.kt
@@ -50,7 +50,7 @@ class GuessServiceTest {
 
         val response: GuessService.GuessGameResponse = target.guessGame(3, "today 2PM", "Z")
         assertFalse { response.success }
-        assertEquals("Guessing failed, there is no active game with gameId 3", response.failMessage)
+        assertEquals("Guessing failed, there is no active game with game ID #3", response.failMessage)
         assertEquals(3, response.gameId)
     }
 
@@ -65,7 +65,7 @@ class GuessServiceTest {
 
         val response: GuessService.GuessGameResponse = target.guessGame(4, "today 2PM", "Z")
         assertFalse { response.success }
-        assertEquals("Guessing failed, guess time is not between start and closing window of game 4", response.failMessage)
+        assertEquals("Guessing failed, guess time is not between start and closing window of game #4", response.failMessage)
         assertEquals(4, response.gameId)
     }
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessServiceTest.kt
@@ -1,0 +1,71 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import io.mockk.every
+import io.mockk.mockk
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException
+import org.junit.jupiter.api.DisplayName
+import uk.co.mutuallyassureddistraction.paketliga.dao.GuessDao
+import java.sql.SQLException
+import kotlin.test.*
+
+class GuessServiceTest {
+    private lateinit var target: GuessService
+
+    @DisplayName("guessGame() will create a guess successfully")
+    @Test
+    fun returnCreateGuessWithSuccessTrue() {
+        val guessDao = mockk<GuessDao>()
+        every {guessDao.createGuess(any())} returns Unit
+        target = GuessService(guessDao)
+
+        val response: GuessService.GuessGameResponse = target.guessGame(1, "today 2PM", "Z")
+        assertTrue { response.success }
+        assertNull(response.failMessage)
+        assertEquals(1, response.gameId)
+    }
+
+    @DisplayName("guessGame() will fail to create a guess because of duplicate guess time")
+    @Test
+    fun returnCreateGuessWithFailedMessageDueToDuplicateGuessTime() {
+        val guessDao = mockk<GuessDao>()
+        val sqlException = SQLException("Guess time has already exist", "23505")
+        val exception = UnableToExecuteStatementException(sqlException, null)
+        every {guessDao.createGuess(any())} throws exception
+        target = GuessService(guessDao)
+
+        val response: GuessService.GuessGameResponse = target.guessGame(2, "today 2PM", "Z")
+        assertFalse { response.success }
+        assertEquals("Guessing failed, there is already a guess with time today 2PM", response.failMessage)
+        assertEquals(2, response.gameId)
+    }
+
+    @DisplayName("guessGame() will fail to create a guess because of nonexistent Game")
+    @Test
+    fun returnCreateGuessWithFailedMessageDueToNonexistentGame() {
+        val guessDao = mockk<GuessDao>()
+        val sqlException = SQLException("Game ID does not exist", "ERRA0")
+        val exception = UnableToExecuteStatementException(sqlException, null)
+        every {guessDao.createGuess(any())} throws exception
+        target = GuessService(guessDao)
+
+        val response: GuessService.GuessGameResponse = target.guessGame(3, "today 2PM", "Z")
+        assertFalse { response.success }
+        assertEquals("Guessing failed, there is no active game with gameId 3", response.failMessage)
+        assertEquals(3, response.gameId)
+    }
+
+    @DisplayName("guessGame() will fail to create a guess because guess time is not between guess window time")
+    @Test
+    fun returnCreateGuessWithFailedMessageDueToGuessTimeOutOfRange() {
+        val guessDao = mockk<GuessDao>()
+        val sqlException = SQLException("Guess time is not between start and closing window range of the game", "ERRA1")
+        val exception = UnableToExecuteStatementException(sqlException, null)
+        every {guessDao.createGuess(any())} throws exception
+        target = GuessService(guessDao)
+
+        val response: GuessService.GuessGameResponse = target.guessGame(4, "today 2PM", "Z")
+        assertFalse { response.success }
+        assertEquals("Guessing failed, guess time is not between start and closing window of game 4", response.failMessage)
+        assertEquals(4, response.gameId)
+    }
+}

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessUpsertServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessUpsertServiceTest.kt
@@ -8,17 +8,17 @@ import uk.co.mutuallyassureddistraction.paketliga.dao.GuessDao
 import java.sql.SQLException
 import kotlin.test.*
 
-class GuessServiceTest {
-    private lateinit var target: GuessService
+class GuessUpsertServiceTest {
+    private lateinit var target: GuessUpsertService
 
     @DisplayName("guessGame() will create a guess successfully")
     @Test
     fun returnCreateGuessWithSuccessTrue() {
         val guessDao = mockk<GuessDao>()
         every {guessDao.createGuess(any())} returns Unit
-        target = GuessService(guessDao)
+        target = GuessUpsertService(guessDao)
 
-        val response: GuessService.GuessGameResponse = target.guessGame(1, "today 2PM", "Z")
+        val response: GuessUpsertService.GuessGameResponse = target.guessGame(1, "today 2PM", "Z")
         assertTrue { response.success }
         assertNull(response.failMessage)
         assertEquals(1, response.gameId)
@@ -31,9 +31,9 @@ class GuessServiceTest {
         val sqlException = SQLException("Guess time has already exist", "23505")
         val exception = UnableToExecuteStatementException(sqlException, null)
         every {guessDao.createGuess(any())} throws exception
-        target = GuessService(guessDao)
+        target = GuessUpsertService(guessDao)
 
-        val response: GuessService.GuessGameResponse = target.guessGame(2, "today 2PM", "Z")
+        val response: GuessUpsertService.GuessGameResponse = target.guessGame(2, "today 2PM", "Z")
         assertFalse { response.success }
         assertEquals("Guessing failed, there is already a guess with time today 2PM", response.failMessage)
         assertEquals(2, response.gameId)
@@ -46,9 +46,9 @@ class GuessServiceTest {
         val sqlException = SQLException("Game ID does not exist", "ERRA0")
         val exception = UnableToExecuteStatementException(sqlException, null)
         every {guessDao.createGuess(any())} throws exception
-        target = GuessService(guessDao)
+        target = GuessUpsertService(guessDao)
 
-        val response: GuessService.GuessGameResponse = target.guessGame(3, "today 2PM", "Z")
+        val response: GuessUpsertService.GuessGameResponse = target.guessGame(3, "today 2PM", "Z")
         assertFalse { response.success }
         assertEquals("Guessing failed, there is no active game with game ID #3", response.failMessage)
         assertEquals(3, response.gameId)
@@ -61,9 +61,9 @@ class GuessServiceTest {
         val sqlException = SQLException("Guess time is not between start and closing window range of the game", "ERRA1")
         val exception = UnableToExecuteStatementException(sqlException, null)
         every {guessDao.createGuess(any())} throws exception
-        target = GuessService(guessDao)
+        target = GuessUpsertService(guessDao)
 
-        val response: GuessService.GuessGameResponse = target.guessGame(4, "today 2PM", "Z")
+        val response: GuessUpsertService.GuessGameResponse = target.guessGame(4, "today 2PM", "Z")
         assertFalse { response.success }
         assertEquals("Guessing failed, guess time is not between start and closing window of game #4", response.failMessage)
         assertEquals(4, response.gameId)


### PR DESCRIPTION
(This PR is dependent on https://github.com/OhDearMoshe/pkl/pull/25, see only commit 0bf4fe586d661f88c61e0e9bea0dad070157ed5b)

Added new DAOs: Point and Win. The idea is to keep track of winnings for a certain game by referring it to the guess, while also having another table to keep track of user's points. See diagram below:

<img width="745" alt="image" src="https://github.com/OhDearMoshe/pkl/assets/4649248/d9f642f7-dd9f-424b-a87d-b164a53e16d5">

```
./gradlew build
BUILD SUCCESSFUL in 47s
```