### PR TITLE
Added LeaderboardExtension and LeaderboardService

### DIFF
--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -43,6 +43,7 @@ suspend fun main() {
         val gameUpsertService = GameUpsertService(gameDao, guessFinderService)
         val gameResultResolver = GameResultResolver()
         val gameEndService = GameEndService(guessDao, gameDao, pointDao, winDao, gameResultResolver)
+        val leaderboardService = LeaderboardService(pointDao)
 
         val createGameExtension = CreateGameExtension(gameUpsertService, SERVER_ID)
         val updateGameExtension = UpdateGameExtension(gameUpsertService, SERVER_ID)
@@ -50,6 +51,7 @@ suspend fun main() {
         val guessGameExtension = GuessGameExtension(guessUpsertService, SERVER_ID)
         val findGuessExtension = FindGuessExtension(guessFinderService, SERVER_ID)
         val endGameExtension = EndGameExtension(gameEndService, SERVER_ID)
+        val leaderboardExtension = LeaderboardExtension(leaderboardService, SERVER_ID)
 
         val bot = ExtensibleBot(BOT_TOKEN) {
             chatCommands {
@@ -64,6 +66,7 @@ suspend fun main() {
                 add { guessGameExtension }
                 add { findGuessExtension }
                 add { endGameExtension }
+                add { leaderboardExtension }
             }
         }
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDao.kt
@@ -1,5 +1,6 @@
 package uk.co.mutuallyassureddistraction.paketliga.dao
 
+import org.jdbi.v3.sqlobject.statement.SqlQuery
 import org.jdbi.v3.sqlobject.statement.SqlUpdate
 import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Point
 
@@ -52,4 +53,16 @@ interface PointDao {
         RETURNING *
     """)
     fun addLost(point: Point)
+
+    @SqlQuery("""
+        SELECT * FROM POINT
+        ORDER BY totalPoint DESC;
+    """)
+    fun getPointsSortedByTotalPointsDesc(): List<Point>
+
+    @SqlQuery("""
+        SELECT * FROM POINT
+        WHERE userId = :userId
+    """)
+    fun getPointByUserId(userId: String): Point
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/LeaderboardExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/LeaderboardExtension.kt
@@ -1,0 +1,74 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalUser
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respondEphemeral
+import com.kotlindiscord.kord.extensions.types.respondingPaginator
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.MemberBehavior
+import dev.kord.rest.builder.message.EmbedBuilder
+import uk.co.mutuallyassureddistraction.paketliga.matching.LeaderboardService
+
+class LeaderboardExtension(private val leaderboardService: LeaderboardService, private val serverId: Snowflake): Extension() {
+    override val name = "leaderboardExtension"
+
+    override suspend fun setup() {
+        publicSlashCommand(::LeaderboardArgs) {
+            name = "leaderboard"
+            description = "Get leaderboard"
+
+            guild(serverId)
+
+            action {
+                val userId = arguments.userId?.asUser()?.id?.value?.toString()
+
+                val leaderboard = leaderboardService.getLeaderboard(userId)
+
+                if(leaderboard.isEmpty()) {
+                    respondEphemeral {
+                        content = "No data found"
+                    }
+                } else {
+                    val kord = this@LeaderboardExtension.kord
+
+                    val paginator = respondingPaginator {
+                        var counter = 1
+                        leaderboard.chunked(10).map { response ->
+                            val pageFields = ArrayList<EmbedBuilder.Field>()
+                            response.forEach {
+                                val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+
+                                val field = EmbedBuilder.Field()
+                                field.name =
+                                    "# " + counter + " : " + memberBehavior.asMember().displayName +
+                                            " | " + it.totalPoint + " points"
+                                field.value = "Played: " + it.played + " - Won: " + it.won + " - Lost: " + it.lost
+                                pageFields.add(field)
+                                counter++
+                            }
+
+                            page {
+                                title = "PaketLiga Leaderboard: "
+                                fields = pageFields
+                            }
+                        }
+
+                        // This will make the pagination function (next prev etc) to disappear after timeout time
+                        timeoutSeconds = 20L
+                    }
+
+                    paginator.send()
+                }
+            }
+        }
+    }
+
+    inner class LeaderboardArgs : Arguments() {
+        val userId by optionalUser {
+            name = "username"
+            description = "Username inputted by the user"
+        }
+    }
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardService.kt
@@ -1,0 +1,22 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import uk.co.mutuallyassureddistraction.paketliga.dao.PointDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Point
+
+class LeaderboardService(private val pointDao: PointDao) {
+    fun getLeaderboard(userId: String?): List<Point> {
+        try {
+            if (userId == null) {
+                return pointDao.getPointsSortedByTotalPointsDesc()
+            }
+
+            val userPoint = pointDao.getPointByUserId(userId) ?: return arrayListOf()
+
+            return arrayListOf(userPoint)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
+        return arrayListOf()
+    }
+}

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDaoTest.kt
@@ -82,6 +82,29 @@ class PointDaoTest {
         assertEquals(secondResult.lost, 2)
     }
 
+    @DisplayName("getPointsSortedByTotalPointsDesc() will return all points sorted descending")
+    @Test
+    fun canSuccessfullyGetPointsDescFromTable() {
+        target.addWin(Point(1,"Z",1,1,1,1))
+        target.addWin(Point(2,"Y",1,1,1,3))
+        target.addWin(Point(3,"X",1,1,1,2))
+        val points = target.getPointsSortedByTotalPointsDesc()
+        assertEquals(points[0].userId, "Y")
+        assertEquals(points[1].userId, "X")
+        assertEquals(points[2].userId, "Z")
+        assertEquals(points[0].totalPoint, 3)
+        assertEquals(points[1].totalPoint, 2)
+        assertEquals(points[2].totalPoint, 1)
+    }
+
+    @DisplayName("getPointByUserId() will return point by user id")
+    @Test
+    fun canSuccessfullyGetPointByUserId() {
+        target.addWin(Point(1, "Z", 1, 1, 1, 1))
+        val point = target.getPointByUserId("Z")
+        assertEquals(point.userId, "Z")
+    }
+
     private fun createdPoint(): Point {
         return Point(
             pointId = 1,

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardServiceTest.kt
@@ -1,0 +1,45 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import uk.co.mutuallyassureddistraction.paketliga.dao.PointDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Point
+import kotlin.test.assertEquals
+
+class LeaderboardServiceTest {
+    private lateinit var target: LeaderboardService
+
+    @BeforeEach
+    fun setUp() {
+        val pointDao = mockk<PointDao>()
+        Point(1,"Z",1,1,1,1)
+
+        every {pointDao.getPointByUserId(any())} returns Point(2,"Y",1,1,1,3)
+        every {pointDao.getPointsSortedByTotalPointsDesc()} returns arrayListOf(
+            Point(2,"Y",1,1,1,3),
+            Point(1,"Z",1,1,1,1)
+        )
+
+        target = LeaderboardService(pointDao)
+    }
+
+    @DisplayName("getLeaderboard() with userid will return one point")
+    @Test
+    fun whenGetWithUserIdReturnOnePoint() {
+        val points = target.getLeaderboard("Y")
+        assertEquals(points.size, 1)
+        assertEquals(points[0].userId, "Y")
+    }
+
+    @DisplayName("getLeaderboard() with null userid will return all points")
+    @Test
+    fun whenGetWithoutUserIdReturnAllPoints() {
+        val points = target.getLeaderboard(null)
+        assertEquals(points.size, 2)
+        assertEquals(points[0].userId, "Y")
+        assertEquals(points[1].userId, "Z")
+    }
+}


### PR DESCRIPTION
Added LeaderboardService:
- With userId will return single point by that userId
- Without userId will return all points

Added LeaderboardExtension:
- With command /leaderboard

Tested in private server:

Without data:
<img width="207" alt="image" src="https://github.com/OhDearMoshe/pkl/assets/4649248/4f671b26-c70f-4832-8c3e-21bf0aca3f58">

With data (not tested with multiple data, but should be similar):
<img width="228" alt="image" src="https://github.com/OhDearMoshe/pkl/assets/4649248/e7790efc-bd23-4648-9624-36fe11a93d68">

```
./gradlew build
BUILD SUCCESSFUL in 1m 13s
8 actionable tasks: 7 executed, 1 up-to-date
```
