### PR TITLE
Update guessing and game searching/creation mechanism

### DIFF
--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -38,7 +38,7 @@ suspend fun main() {
         val pointDao = jdbi.onDemand<PointDao>()
         val winDao = jdbi.onDemand<WinDao>()
         val gameFinderService = GameFinderService(gameDao)
-        val guessUpsertService = GuessUpsertService(guessDao)
+        val guessUpsertService = GuessUpsertService(guessDao, gameDao)
         val guessFinderService = GuessFinderService(guessDao)
         val gameUpsertService = GameUpsertService(gameDao, guessFinderService)
         val gameResultResolver = GameResultResolver()

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -43,6 +43,7 @@ suspend fun main() {
         val gameUpsertService = GameUpsertService(gameDao, guessFinderService)
         val gameResultResolver = GameResultResolver()
         val gameEndService = GameEndService(guessDao, gameDao, pointDao, winDao, gameResultResolver)
+        val leaderboardService = LeaderboardService(pointDao)
 
         val createGameExtension = CreateGameExtension(gameUpsertService, SERVER_ID)
         val updateGameExtension = UpdateGameExtension(gameUpsertService, SERVER_ID)
@@ -50,6 +51,7 @@ suspend fun main() {
         val guessGameExtension = GuessGameExtension(guessUpsertService, SERVER_ID)
         val findGuessExtension = FindGuessExtension(guessFinderService, SERVER_ID)
         val endGameExtension = EndGameExtension(gameEndService, SERVER_ID)
+        val leaderboardExtension = LeaderboardExtension(leaderboardService, SERVER_ID)
 
         val bot = ExtensibleBot(BOT_TOKEN) {
             chatCommands {
@@ -64,6 +66,7 @@ suspend fun main() {
                 add { guessGameExtension }
                 add { findGuessExtension }
                 add { endGameExtension }
+                add { leaderboardExtension }
             }
         }
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GameDao.kt
@@ -2,12 +2,11 @@ package uk.co.mutuallyassureddistraction.paketliga.dao
 
 import org.jdbi.v3.sqlobject.customizer.Bind
 import org.jdbi.v3.sqlobject.statement.SqlQuery
-import org.jdbi.v3.sqlobject.statement.SqlUpdate
 import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
 import java.time.ZonedDateTime
 
 interface GameDao {
-     @SqlUpdate("""
+     @SqlQuery("""
           INSERT INTO GAME(
                gameName,
                windowStart,
@@ -26,8 +25,9 @@ interface GameDao {
                :game.userId,
                :game.gameActive
           )
+          RETURNING *
      """)
-     fun createGame(game: Game)
+     fun createGame(game: Game): Game
 
      @SqlQuery("""
           UPDATE GAME

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDao.kt
@@ -8,7 +8,7 @@ import java.util.*
 
 interface GuessDao {
     @SqlUpdate("""
-            INSERT INTO GUESS(
+            INSERT INTO GUESS as gss(
                 gameId,
                 userId,
                 guessTime
@@ -17,7 +17,11 @@ interface GuessDao {
                 :guess.gameId,
                 :guess.userId,
                 :guess.guessTime
-            )
+            ) 
+            ON CONFLICT ON CONSTRAINT game_and_user_id DO UPDATE
+                SET 
+                    guessTime = :guess.guessTime
+                WHERE gss.userId = :guess.userId
         """)
     fun createGuess(guess: Guess)
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDao.kt
@@ -1,5 +1,6 @@
 package uk.co.mutuallyassureddistraction.paketliga.dao
 
+import org.jdbi.v3.sqlobject.statement.SqlQuery
 import org.jdbi.v3.sqlobject.statement.SqlUpdate
 import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Point
 
@@ -52,4 +53,16 @@ interface PointDao {
         RETURNING *
     """)
     fun addLost(point: Point)
+
+    @SqlQuery("""
+        SELECT * FROM POINT
+        ORDER BY totalPoint DESC;
+    """)
+    fun getPointsSortedByTotalPointsDesc(): List<Point>
+
+    @SqlQuery("""
+        SELECT * FROM POINT
+        WHERE userId = :userId
+    """)
+    fun getPointByUserId(userId: String): Point
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/LeaderboardExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/LeaderboardExtension.kt
@@ -1,0 +1,74 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalUser
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respondEphemeral
+import com.kotlindiscord.kord.extensions.types.respondingPaginator
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.MemberBehavior
+import dev.kord.rest.builder.message.EmbedBuilder
+import uk.co.mutuallyassureddistraction.paketliga.matching.LeaderboardService
+
+class LeaderboardExtension(private val leaderboardService: LeaderboardService, private val serverId: Snowflake): Extension() {
+    override val name = "leaderboardExtension"
+
+    override suspend fun setup() {
+        publicSlashCommand(::LeaderboardArgs) {
+            name = "leaderboard"
+            description = "Get leaderboard"
+
+            guild(serverId)
+
+            action {
+                val userId = arguments.userId?.asUser()?.id?.value?.toString()
+
+                val leaderboard = leaderboardService.getLeaderboard(userId)
+
+                if(leaderboard.isEmpty()) {
+                    respondEphemeral {
+                        content = "No data found"
+                    }
+                } else {
+                    val kord = this@LeaderboardExtension.kord
+
+                    val paginator = respondingPaginator {
+                        var counter = 1
+                        leaderboard.chunked(10).map { response ->
+                            val pageFields = ArrayList<EmbedBuilder.Field>()
+                            response.forEach {
+                                val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+
+                                val field = EmbedBuilder.Field()
+                                field.name =
+                                    "# " + counter + " : " + memberBehavior.asMember().displayName +
+                                            " | " + it.totalPoint + " points"
+                                field.value = "Played: " + it.played + " - Won: " + it.won + " - Lost: " + it.lost
+                                pageFields.add(field)
+                                counter++
+                            }
+
+                            page {
+                                title = "PaketLiga Leaderboard: "
+                                fields = pageFields
+                            }
+                        }
+
+                        // This will make the pagination function (next prev etc) to disappear after timeout time
+                        timeoutSeconds = 20L
+                    }
+
+                    paginator.send()
+                }
+            }
+        }
+    }
+
+    inner class LeaderboardArgs : Arguments() {
+        val userId by optionalUser {
+            name = "username"
+            description = "Username inputted by the user"
+        }
+    }
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/UpdateGameExtension.kt
@@ -39,17 +39,19 @@ class UpdateGameExtension(private val gameUpsertService: GameUpsertService, priv
                         content = responseString[0]
                     }
 
-                    val kord = this@UpdateGameExtension.kord
-                    var mentionContent = "Mentioning users that have guessed:"
-                    userIds.forEach {
-                        val memberBehavior = MemberBehavior(serverId, Snowflake(it), kord)
-                        mentionContent += " " + memberBehavior.asMember().mention
-                    }
+                    if(userIds.isNotEmpty()) {
+                        val kord = this@UpdateGameExtension.kord
+                        var mentionContent = "Mentioning users that have guessed:"
+                        userIds.forEach {
+                            val memberBehavior = MemberBehavior(serverId, Snowflake(it), kord)
+                            mentionContent += " " + memberBehavior.asMember().mention
+                        }
 
-                    mentionContent += " " + "as a notice that a game has been updated and possibly the time has changed"
+                        mentionContent += " " + "as a notice that a game has been updated and possibly the time has changed"
 
-                    respond {
-                        content = mentionContent
+                        respond {
+                            content = mentionContent
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertService.kt
@@ -37,12 +37,11 @@ class GameUpsertService(private val gameDao: GameDao, private val guessFinderSer
             val guessesCloseDate = guessesCloseDates.parserOutputs[0].dateRange.start
             val gameName = userGameName ?: "Game"
 
-            val gameNameString = gameNameStringMaker(gameName, member, username)
             val startDateString = startDate.toString(dtf)
             val closeDateString = closeDate.toString(dtf)
             val guessesCloseDateString = guessesCloseDate.toString(dtf)
 
-            gameDao.createGame(
+            val createdGame = gameDao.createGame(
                 Game(
                     gameId = null,
                     gameName = gameName,
@@ -54,6 +53,8 @@ class GameUpsertService(private val gameDao: GameDao, private val guessFinderSer
                     gameActive = true
                 )
             )
+
+            val gameNameString = gameNameStringMaker(gameName, member, username, createdGame.gameId!!)
 
             return gameNameString + " : package arriving between " + startDateString + " and " + closeDateString +
                     ". Guesses accepted until " + guessesCloseDateString
@@ -112,13 +113,13 @@ class GameUpsertService(private val gameDao: GameDao, private val guessFinderSer
         return parser.parse(dateString, referenceDate, hawkingConfiguration, "eng")
     }
 
-    private fun gameNameStringMaker(gameName: String?, member: Member?, username: String): String {
+    private fun gameNameStringMaker(gameName: String?, member: Member?, username: String, gameId: Int): String {
         return if(member != null) {
-            "$gameName by ${member.mention}"
+            "$gameName (#$gameId) by ${member.mention}"
         } else {
             // We need username for non-server users that are using this command, if any (hence the nullable Member)
             // Kinda unlikely, but putting this here just in case
-            "$gameName by $username"
+            "$gameName (#$gameId) by $username"
         }
     }
 }

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardService.kt
@@ -1,0 +1,22 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import uk.co.mutuallyassureddistraction.paketliga.dao.PointDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Point
+
+class LeaderboardService(private val pointDao: PointDao) {
+    fun getLeaderboard(userId: String?): List<Point> {
+        try {
+            if (userId == null) {
+                return pointDao.getPointsSortedByTotalPointsDesc()
+            }
+
+            val userPoint = pointDao.getPointByUserId(userId) ?: return arrayListOf()
+
+            return arrayListOf(userPoint)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
+        return arrayListOf()
+    }
+}

--- a/src/main/resources/GuessTrigger.sql
+++ b/src/main/resources/GuessTrigger.sql
@@ -1,9 +1,6 @@
 CREATE OR REPLACE FUNCTION check_gameid_and_guesstime()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF NOT EXISTS (SELECT 1 FROM game WHERE gameid = NEW.gameid) THEN
-        RAISE EXCEPTION 'Game ID % does not exist.', NEW.gameid USING ERRCODE = 'ERRA0';
-    END IF;
     IF NOT (NEW.guesstime BETWEEN (SELECT windowstart FROM game WHERE gameid = NEW.gameid) AND (SELECT windowclose FROM game WHERE gameid = NEW.gameid)) THEN
         RAISE EXCEPTION 'Guess time % is not between start and closing window range of the game', NEW.guesstime USING ERRCODE = 'ERRA1';
     END IF;

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/DaoTestUtils.kt
@@ -73,7 +73,8 @@ fun setUpDatabaseTables(jdbi: Jdbi) {
                     FOREIGN KEY (gameId) 
                         REFERENCES GAME(gameId)
                         ON DELETE CASCADE,
-                CONSTRAINT game_and_guess_time UNIQUE (gameId, guessTime)
+                CONSTRAINT game_and_guess_time UNIQUE (gameId, guessTime),
+                CONSTRAINT game_and_user_id UNIQUE (gameId, userId)
             )
         """.trimIndent())
         batch.add("""

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/GuessDaoTest.kt
@@ -179,4 +179,30 @@ class GuessDaoTest {
         val result = target.findGuessesByGameId(999)
         assertTrue { result.isEmpty() }
     }
+
+    @DisplayName("createGuess() will update data if user has guessed before")
+    @Test
+    fun canSuccessfullyUpdateDataWhenUserHasGuessedBefore() {
+        val expected = Guess(
+            null,
+            gameId = 1,
+            userId = "PostMasterGeneral",
+            guessTime = ZonedDateTime.parse("2023-04-07T16:00:00.000Z[Europe/London]")
+        )
+        target.createGuess(expected)
+
+        val expected2 = Guess(
+            null,
+            gameId = 1,
+            userId = "PostMasterGeneral",
+            guessTime = ZonedDateTime.parse("2023-04-07T17:00:00.000Z[Europe/London]")
+        )
+        target.createGuess(expected2)
+
+        val result = target.findGuessesByGameId(1)
+        assertEquals(result.size, 1)
+        assertEquals(result[0].userId, expected2.userId)
+        assertEquals(result[0].gameId, expected2.gameId)
+        assertEquals(result[0].guessTime, expected2.guessTime)
+    }
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/PointDaoTest.kt
@@ -82,6 +82,29 @@ class PointDaoTest {
         assertEquals(secondResult.lost, 2)
     }
 
+    @DisplayName("getPointsSortedByTotalPointsDesc() will return all points sorted descending")
+    @Test
+    fun canSuccessfullyGetPointsDescFromTable() {
+        target.addWin(Point(1,"Z",1,1,1,1))
+        target.addWin(Point(2,"Y",1,1,1,3))
+        target.addWin(Point(3,"X",1,1,1,2))
+        val points = target.getPointsSortedByTotalPointsDesc()
+        assertEquals(points[0].userId, "Y")
+        assertEquals(points[1].userId, "X")
+        assertEquals(points[2].userId, "Z")
+        assertEquals(points[0].totalPoint, 3)
+        assertEquals(points[1].totalPoint, 2)
+        assertEquals(points[2].totalPoint, 1)
+    }
+
+    @DisplayName("getPointByUserId() will return point by user id")
+    @Test
+    fun canSuccessfullyGetPointByUserId() {
+        target.addWin(Point(1, "Z", 1, 1, 1, 1))
+        val point = target.getPointByUserId("Z")
+        assertEquals(point.userId, "Z")
+    }
+
     private fun createdPoint(): Point {
         return Point(
             pointId = 1,

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GameUpsertServiceTest.kt
@@ -23,7 +23,7 @@ class GameUpsertServiceTest {
     fun setUp() {
         val gameDao = mockk<GameDao>()
         val guessFinderService = mockk<GuessFinderService>()
-        every {gameDao.createGame(any())} returns Unit
+        every {gameDao.createGame(any())} returns getGameStub()
         every {gameDao.findActiveGameById(999)} returns null
         every {gameDao.findActiveGameById(1)} returns mockk<Game>()
         every {gameDao.updateGameTimes(any(), any(), any(), any())} returns getUpdatedGameStub()
@@ -119,11 +119,24 @@ class GameUpsertServiceTest {
         val gameName = userGameName ?: "Game"
 
         return if(member != null) {
-            "$gameName by ${member.mention}" + " : package arriving between " + startTime + " and " + closeTime +
+            "$gameName (#1) by ${member.mention}" + " : package arriving between " + startTime + " and " + closeTime +
                     ". Guesses accepted until " + guessesCloseTime
         } else {
-            "$gameName by $username" + " : package arriving between " + startTime + " and " + closeTime +
+            "$gameName (#1) by $username" + " : package arriving between " + startTime + " and " + closeTime +
                     ". Guesses accepted until " + guessesCloseTime
         }
+    }
+
+    private fun getGameStub(): Game {
+        return Game(
+            gameId = 1,
+            gameName = "Testing testing",
+            windowStart = ZonedDateTime.now().withHour(15).withMinute(0),
+            windowClose = ZonedDateTime.now().withHour(19).withMinute(0),
+            guessesClose = ZonedDateTime.now().withHour(14).withMinute(0),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
     }
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessUpsertServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/GuessUpsertServiceTest.kt
@@ -2,21 +2,30 @@ package uk.co.mutuallyassureddistraction.paketliga.matching
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException
 import org.junit.jupiter.api.DisplayName
+import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
 import uk.co.mutuallyassureddistraction.paketliga.dao.GuessDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
 import java.sql.SQLException
+import java.time.ZonedDateTime
 import kotlin.test.*
 
 class GuessUpsertServiceTest {
     private lateinit var target: GuessUpsertService
+
+    private val javaDtf: java.time.format.DateTimeFormatter = java.time.format.DateTimeFormatter.ofPattern("dd-MMM-yy HH:mm")
 
     @DisplayName("guessGame() will create a guess successfully")
     @Test
     fun returnCreateGuessWithSuccessTrue() {
         val guessDao = mockk<GuessDao>()
         every {guessDao.createGuess(any())} returns Unit
-        target = GuessUpsertService(guessDao)
+        val gameDao = mockk<GameDao>()
+        every {gameDao.findActiveGameById(any())} returns getGameStub()
+        target = GuessUpsertService(guessDao, gameDao)
 
         val response: GuessUpsertService.GuessGameResponse = target.guessGame(1, "today 2PM", "Z")
         assertTrue { response.success }
@@ -31,7 +40,9 @@ class GuessUpsertServiceTest {
         val sqlException = SQLException("Guess time has already exist", "23505")
         val exception = UnableToExecuteStatementException(sqlException, null)
         every {guessDao.createGuess(any())} throws exception
-        target = GuessUpsertService(guessDao)
+        val gameDao = mockk<GameDao>()
+        every {gameDao.findActiveGameById(any())} returns getGameStub()
+        target = GuessUpsertService(guessDao, gameDao)
 
         val response: GuessUpsertService.GuessGameResponse = target.guessGame(2, "today 2PM", "Z")
         assertFalse { response.success }
@@ -43,10 +54,10 @@ class GuessUpsertServiceTest {
     @Test
     fun returnCreateGuessWithFailedMessageDueToNonexistentGame() {
         val guessDao = mockk<GuessDao>()
-        val sqlException = SQLException("Game ID does not exist", "ERRA0")
-        val exception = UnableToExecuteStatementException(sqlException, null)
-        every {guessDao.createGuess(any())} throws exception
-        target = GuessUpsertService(guessDao)
+        every {guessDao.createGuess(any())} returns Unit
+        val gameDao = mockk<GameDao>()
+        every {gameDao.findActiveGameById(any())} returns null
+        target = GuessUpsertService(guessDao, gameDao)
 
         val response: GuessUpsertService.GuessGameResponse = target.guessGame(3, "today 2PM", "Z")
         assertFalse { response.success }
@@ -61,11 +72,49 @@ class GuessUpsertServiceTest {
         val sqlException = SQLException("Guess time is not between start and closing window range of the game", "ERRA1")
         val exception = UnableToExecuteStatementException(sqlException, null)
         every {guessDao.createGuess(any())} throws exception
-        target = GuessUpsertService(guessDao)
+        val gameDao = mockk<GameDao>()
+        every {gameDao.findActiveGameById(any())} returns getGameStub()
+        target = GuessUpsertService(guessDao, gameDao)
 
         val response: GuessUpsertService.GuessGameResponse = target.guessGame(4, "today 2PM", "Z")
         assertFalse { response.success }
         assertEquals("Guessing failed, guess time is not between start and closing window of game #4", response.failMessage)
         assertEquals(4, response.gameId)
+    }
+
+    @DisplayName("guessGame() will fail to create a guess because guessing deadline has passed")
+    @Test
+    fun returnCreateGuessWithFailedMessageDueToPassedGuessingDeadline() {
+        val guessDao = mockk<GuessDao>()
+        every {guessDao.createGuess(any())} returns Unit
+        val gameStub = getGameStub()
+        val gameDao = mockk<GameDao>()
+        every {gameDao.findActiveGameById(any())} returns gameStub
+
+        val mockZonedDateTime = ZonedDateTime.now().withHour(18).withMinute(1)
+        mockkStatic(ZonedDateTime::class)
+        every {ZonedDateTime.now()} returns mockZonedDateTime
+        target = GuessUpsertService(guessDao, gameDao)
+
+        val response: GuessUpsertService.GuessGameResponse = target.guessGame(3, "today 2PM", "Z")
+        assertFalse { response.success }
+        assertEquals("Guessing failed, guessing deadline for game #3 has passed, guessing deadline was at " +
+            gameStub.guessesClose.format(javaDtf), response.failMessage)
+        assertEquals(3, response.gameId)
+
+        unmockkStatic(ZonedDateTime::class)
+    }
+
+    private fun getGameStub(): Game {
+        return Game(
+            gameId = 1,
+            gameName = "Testing testing",
+            windowStart = ZonedDateTime.now().withHour(11).withMinute(0),
+            windowClose = ZonedDateTime.now().withHour(19).withMinute(0),
+            guessesClose = ZonedDateTime.now().withHour(18).withMinute(0),
+            deliveryTime = null,
+            userId = "Z",
+            gameActive = true
+        )
     }
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardServiceTest.kt
@@ -1,0 +1,45 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import uk.co.mutuallyassureddistraction.paketliga.dao.PointDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Point
+import kotlin.test.assertEquals
+
+class LeaderboardServiceTest {
+    private lateinit var target: LeaderboardService
+
+    @BeforeEach
+    fun setUp() {
+        val pointDao = mockk<PointDao>()
+        Point(1,"Z",1,1,1,1)
+
+        every {pointDao.getPointByUserId(any())} returns Point(2,"Y",1,1,1,3)
+        every {pointDao.getPointsSortedByTotalPointsDesc()} returns arrayListOf(
+            Point(2,"Y",1,1,1,3),
+            Point(1,"Z",1,1,1,1)
+        )
+
+        target = LeaderboardService(pointDao)
+    }
+
+    @DisplayName("getLeaderboard() with userid will return one point")
+    @Test
+    fun whenGetWithUserIdReturnOnePoint() {
+        val points = target.getLeaderboard("Y")
+        assertEquals(points.size, 1)
+        assertEquals(points[0].userId, "Y")
+    }
+
+    @DisplayName("getLeaderboard() with null userid will return all points")
+    @Test
+    fun whenGetWithoutUserIdReturnAllPoints() {
+        val points = target.getLeaderboard(null)
+        assertEquals(points.size, 2)
+        assertEquals(points[0].userId, "Y")
+        assertEquals(points[1].userId, "Z")
+    }
+}


### PR DESCRIPTION
(This PR is dependent on https://github.com/OhDearMoshe/pkl/pull/30, see only commit 5642dd39de1443ed26920fc9a57e51a1ddb452ba)

- Creating guess twice will now be counted as an update
- Creating game will now show game id to others
- Guessing past the deadline will be blocked
- Find games without param will now show all games


Testing in private server:

Creating guess twice:
<img width="531" alt="image" src="https://github.com/OhDearMoshe/pkl/assets/4649248/da75c4bc-e72f-4ca8-8657-a54672a9730b">
<img width="519" alt="image" src="https://github.com/OhDearMoshe/pkl/assets/4649248/00a1f877-c1ba-45b2-93c9-7b5564c5c424">

Creating game will show game id:
<img width="835" alt="image" src="https://github.com/OhDearMoshe/pkl/assets/4649248/9268f8cc-d073-4a56-9919-e3e219256180">

Guessing past the deadline:
<img width="764" alt="image" src="https://github.com/OhDearMoshe/pkl/assets/4649248/76b43cb7-121a-4291-b410-aa8c152a29f4">

Find games without param:
<img width="472" alt="image" src="https://github.com/OhDearMoshe/pkl/assets/4649248/2e431c9e-120c-4a38-9d2a-a9a778edce69">

```
./gradlew build
BUILD SUCCESSFUL in 49s
8 actionable tasks: 1 executed, 7 up-to-date
```